### PR TITLE
Korrektur von "Listen herunterladen" und "Sammel-PDF" in der Hauptliste

### DIFF
--- a/webapp/views/mod_list.py
+++ b/webapp/views/mod_list.py
@@ -205,7 +205,7 @@ def display_all_pdf():
     collected_groups = []
     for event_class in g.event.classes.filter_by(begin_fighting=True, ended_fighting=False).all():
         for group in event_class.groups.all():
-            if not group.participants.count() == 0 and group.list_system() != None
+            if not group.participants.count() == 0 and group.list_system() != None:
                 collected_groups.append([
                     group,
                     helpers.load_list(group)

--- a/webapp/views/mod_list.py
+++ b/webapp/views/mod_list.py
@@ -165,10 +165,11 @@ def display_all_zip():
     collected_groups = []
     for event_class in g.event.classes.filter_by(begin_fighting=True, ended_fighting=False).all():
         for group in event_class.groups.all():
-            collected_groups.append([
-                group,
-                helpers.load_list(group)
-            ])
+            if not group.participants.count() == 0 and group.list_system() != None:
+                collected_groups.append([
+                    group,
+                    helpers.load_list(group)
+                ])
 
     pdfw = PdfWriter()
 
@@ -193,7 +194,7 @@ def display_all_zip():
     return send_file(pdf_io, mimetype='application/pdf')
 
 
-@mod_list_view.route('/display/all_lists.zip')
+@mod_list_view.route('/display/all_lists.pdf')
 @check_and_apply_event
 @check_is_registered
 def display_all_pdf():
@@ -204,10 +205,11 @@ def display_all_pdf():
     collected_groups = []
     for event_class in g.event.classes.filter_by(begin_fighting=True, ended_fighting=False).all():
         for group in event_class.groups.all():
-            collected_groups.append([
-                group,
-                helpers.load_list(group)
-            ])
+            if not group.participants.count() == 0 and group.list_system() != None
+                collected_groups.append([
+                    group,
+                    helpers.load_list(group)
+                ])
 
     zip_io = io.BytesIO()
     zip_file = zipfile.ZipFile(zip_io, mode='w')

--- a/webapp/views/mod_list.py
+++ b/webapp/views/mod_list.py
@@ -154,10 +154,10 @@ def display_pdf(id):
     return send_file(pdf_io, mimetype='application/pdf')
 
 
-@mod_list_view.route('/display/all_lists.zip')
+@mod_list_view.route('/display/all_lists.pdf')
 @check_and_apply_event
 @check_is_registered
-def display_all_zip():
+def display_all_pdf():
     if not g.device.event_role.may_use_global_list:
         flash('Sie haben keine Berechtigung, hierauf zuzugreifen.', 'danger')
         return redirect(url_for('devices.index', event=g.event.slug))
@@ -194,10 +194,10 @@ def display_all_zip():
     return send_file(pdf_io, mimetype='application/pdf')
 
 
-@mod_list_view.route('/display/all_lists.pdf')
+@mod_list_view.route('/display/all_lists.zip')
 @check_and_apply_event
 @check_is_registered
-def display_all_pdf():
+def display_all_zip():
     if not g.device.event_role.may_use_global_list:
         flash('Sie haben keine Berechtigung, hierauf zuzugreifen.', 'danger')
         return redirect(url_for('devices.index', event=g.event.slug))


### PR DESCRIPTION
## Inhalt

Diese PR behebt zwei Probleme bei den Funktionen (alle) "Listen herunterladen" und "Sammel-PDF in der Hauptliste:

- Die Funktionen zum Herunterladen als ZIP-Sammlung und als Sammel-PDF waren vertauscht
- Leere Listen führten zu einem Fehler bei diesen Funktionen

## Relevante Issues

n. n.

## Release Notes

```
- Ein Fehler wurde behoben, der das Herunterladen von ZIP-Sammlungen und Sammel-PDFs in der Hauptliste verhinderte, wenn leere Listen existierten
- Es führen nicht mehr beide Knöpfe dazu, dass lediglich eine ZIP-Datei heruntergeladen wird, sodass Sammel-PDFs jetzt richtig funktionieren.
```

## Anmerkungen und Implementierungsdetails

n. n.