### PR TITLE
Bessere Dateinamen

### DIFF
--- a/webapp/models/events.py
+++ b/webapp/models/events.py
@@ -5,6 +5,7 @@ from .participants import Group
 import json
 import hashlib
 import datetime
+import re
 
 
 class Event(db.Model):
@@ -203,6 +204,13 @@ class EventClass(db.Model):
     
     def placed_registrations_count(self):
         return self.registrations.filter_by(confirmed=True, registered=True, weighed_in=True, placed=True).count()
+    
+    def download_name(self, file_suffix):
+        name = self.short_title
+        name = name.replace(".", "-")
+        name = re.sub('[^a-zA-Z0-9_-]', '', name)
+        return f"{name}_{file_suffix}"
+
 
 class EventRole(db.Model):
     id = db.Column(db.Integer(), primary_key=True)

--- a/webapp/models/participants.py
+++ b/webapp/models/participants.py
@@ -1,5 +1,6 @@
 from . import db
 import base64
+import re
 
 class Registration(db.Model):
     id = db.Column(db.Integer(), primary_key=True)
@@ -304,6 +305,12 @@ class Group(db.Model):
     
     def all_participants_have_been_placed(self):
         return self.participants.filter(Participant.placement_index != None).count() > 0
+    
+    def download_name(self, file_suffix):
+        name = self.cut_title()
+        name = name.replace(".", "-")
+        name = re.sub('[^a-zA-Z0-9_-]', '', name)
+        return self.event_class.download_name(f"{name}_{file_suffix}")
 
 
 class Participant(db.Model):

--- a/webapp/templates/event-manager/classes/index.html
+++ b/webapp/templates/event-manager/classes/index.html
@@ -48,7 +48,7 @@
             <td>
                 <a href="{{ url_for('event_manager.edit_class', event=g.event.slug, id=cl.id) }}" class="btn btn-sm btn-primary">Bearbeiten</a>
                 <a href="{{ url_for('event_manager.registrations', event=g.event.slug, class_filter=cl.id) }}" class="btn btn-sm btn-secondary">{{ cl.registrations.count() }} TN</a>
-                <a href="{{ url_for('event_manager.class_registrations_as_csv', event=g.event.slug, id=cl.id) }}" class="btn btn-sm btn-secondary">CSV</a>
+                <a href="{{ url_for('event_manager.class_registrations_as_csv', event=g.event.slug, id=cl.id) }}" download="{{ cl.download_name('registrations.csv') }}" class="btn btn-sm btn-secondary">CSV</a>
             </td>
         </tr>
         {% endfor %}

--- a/webapp/templates/event-manager/registrations/index.html
+++ b/webapp/templates/event-manager/registrations/index.html
@@ -79,7 +79,7 @@
     <a href="{{ url_for('event_manager.import_registrations_index', event=g.event.slug) }}" class="btn btn-secondary">TN importieren</a>
     {% if filtered_class %}
     <a href="{{ url_for('event_manager.print_registrations', event=g.event.slug, id=filtered_class.id) }}" class="btn btn-secondary" target="_blank">TN/Wiegeliste drucken ({{ filtered_class.short_title }})</a>
-    <a href="{{ url_for('event_manager.class_registrations_as_csv', event=g.event.slug, id=filtered_class.id) }}" class="btn btn-secondary">CSV exportieren ({{ filtered_class.short_title }})</a>
+    <a href="{{ url_for('event_manager.class_registrations_as_csv', event=g.event.slug, id=filtered_class.id) }}" download="{{ filtered_class.download_name('registrations.csv') }}" class="btn btn-secondary">CSV exportieren ({{ filtered_class.short_title }})</a>
     {% else %}
     <a href="{{ url_for('event_manager.print_registrations', event=g.event.slug) }}" class="btn btn-secondary" target="_blank">TN/Wiegeliste drucken</a>
     <a href="{{ url_for('event_manager.class_registrations_as_csv', event=g.event.slug) }}" class="btn btn-secondary">CSV exportieren</a>

--- a/webapp/templates/mod_global_list/index.html
+++ b/webapp/templates/mod_global_list/index.html
@@ -87,9 +87,8 @@
                 {% endfor %}
             </div>
             {% endfor %}
-
             <a href="{{ url_for('mod_list.display_all_zip', event=g.event.slug) }}" class="btn btn-secondary mb-3">Listen herunterladen</a>
-            <a href="{{ url_for('mod_list.display_all_pdf', event=g.event.slug) }}" download="all_lists.pdf" class="btn btn-secondary mb-3">Sammel-PDF</a>
+            <a href="{{ url_for('mod_list.display_all_pdf', event=g.event.slug) }}" download="all_lists_{{ now.strftime("%Y-%m-%d_%H-%M-%S") }}.pdf" class="btn btn-secondary mb-3">Sammel-PDF</a>
             <a href="{{ url_for('mod_global_list.class_progress', event=g.event.slug) }}" class="btn btn-secondary mb-3">Kampfklassen-Fortschritt</a>
         </div>
         <div class="col-12 col-md-4">
@@ -156,7 +155,7 @@
             <div class="d-flex align-items-center justify-content-between">
                 <div class="mb-3">
                     <a href="{{ url_for('mod_list.display_pdf', event=g.event.slug, id=current_group.id) }}" class="btn btn-secondary btn-sm" target="_blank">Als PDF anzeigen</a>
-                    <a href="{{ url_for('mod_list.display_pdf', event=g.event.slug, id=current_group.id) }}" download="list.pdf" class="btn btn-secondary btn-sm">Als PDF herunterladen</a>
+                    <a href="{{ url_for('mod_list.display_pdf', event=g.event.slug, id=current_group.id) }}" download="{{ current_group.download_name('list.pdf') }}" class="btn btn-secondary btn-sm">Als PDF herunterladen</a>
                 </div>
 
                 <ul class="pagination pagination-sm">

--- a/webapp/templates/mod_results/individual.html
+++ b/webapp/templates/mod_results/individual.html
@@ -8,7 +8,7 @@
 {% for evcl in g.event.classes if evcl.groups.filter_by(completed=True).count() > 0 %}
 <h2 class="h4 mt-4">{{ evcl.title }}</h2>
 <a href="{{ url_for('mod_results.print_class', event=g.event.slug, id=evcl.id) }}" class="btn btn-secondary mb-3 btn-sm" target="_blank">Ergebnisse ausdrucken</a>
-<a href="{{ url_for('mod_results.class_as_csv', event=g.event.slug, id=evcl.id) }}" class="btn btn-secondary mb-3 btn-sm" target="_blank">Als CSV herunterladen</a>
+<a href="{{ url_for('mod_results.class_as_csv', event=g.event.slug, id=evcl.id) }}" class="btn btn-secondary mb-3 btn-sm" download="{{ evcl.download_name('results.csv') }}" target="_blank">Als CSV herunterladen</a>
 
 
 {% for group in evcl.groups.filter_by(completed=True) %}

--- a/webapp/views/event_manager.py
+++ b/webapp/views/event_manager.py
@@ -553,7 +553,7 @@ def class_registrations_as_csv(id=None):
             registration.club,
             registration.association.short_name if registration.association else None,
             registration.suggested_group,
-            registration.verified_weight / 1000,
+            registration.verified_weight / 1000 if registration.verified_weight else '',
             'x' if registration.confirmed else '',
             'x' if registration.registered else '',
             'x' if registration.weighed_in else ''

--- a/webapp/views/mod_global_list.py
+++ b/webapp/views/mod_global_list.py
@@ -55,8 +55,9 @@ def index():
             )
 
     mats = g.event.device_positions.filter_by(is_mat=True).all()
+    now = dt.now()
     
-    return render_template("mod_global_list/index.html", mats=mats, current_group=current_group, free_groups=free_groups, scheduled_matches=scheduled_matches, not_scheduled_matches=not_scheduled_matches,completed_matches=completed_matches, obsolete_matches=obsolete_matches)
+    return render_template("mod_global_list/index.html", mats=mats, current_group=current_group, free_groups=free_groups, scheduled_matches=scheduled_matches, not_scheduled_matches=not_scheduled_matches,completed_matches=completed_matches, obsolete_matches=obsolete_matches, now=now)
 
 
 @mod_global_list_view.route('/group/<id>/edit', methods=['POST'])

--- a/webapp/views/mod_list.py
+++ b/webapp/views/mod_list.py
@@ -237,8 +237,10 @@ def display_all_zip():
     
     zip_file.close()
 
+    now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
     return Response(zip_io.getvalue(), mimetype='application/zip', headers={
-        'Content-Disposition': 'attachment;filename=all_lists.zip'
+        'Content-Disposition': f'attachment;filename=all_lists_{now}.zip'
     })
 
 


### PR DESCRIPTION
## Inhalt

Diese PR verbessert die Dateinamen beim Download von

- allen (aktiven) Listen als PDF oder ZIP in der Hauptliste (Format: `all_lists_YYYY-MM-DD_HH:MM:SS.{zip,pdf}`)
- einzelnen Listen als PDF in der Hauptliste (enthält Kurzname der Kampfklasse und Name der Gruppe)
- den Ergebnissen einer Kampfklasse als CSV im Ergebnismodul (enthält den Kurznamen der Kampfklasse anstelle von - wie bisher - der ID)

## Relevante Issues

n. n.

## Release Notes

```
- Herunterzuladende Dateien haben nun eindeutigere, verständlichere Dateinamen (-> #30)
```

## Anmerkungen und Implementierungsdetails

n. n.