### PR TITLE
Problembehebung bei der Parameter-Tabelle für TN ohne last_fight_at-Wert

### DIFF
--- a/webapp/templates/mod_global_list/parameters.html
+++ b/webapp/templates/mod_global_list/parameters.html
@@ -41,7 +41,7 @@
                             </td>
 
                             <td>
-                                <input class="form-control" type="datetime-local" name="last_fight_at" value="{{ (part.last_fight_at + diff_delta).isoformat().rsplit(":", 1)[0] }}">
+                                <input class="form-control" type="datetime-local" name="last_fight_at" value="{{ (part.last_fight_at + diff_delta).isoformat().rsplit(":", 1)[0] if part.last_fight_at }}">
                             </td>
                             <td>
                                 {% if saved_participant == part.id %}

--- a/webapp/views/mod_global_list.py
+++ b/webapp/views/mod_global_list.py
@@ -121,12 +121,12 @@ def parameters(id):
         participant.removed = 'removed' in request.form
         participant.removal_cause = request.form['removal_cause']
 
-        print(dt.fromisoformat(request.form['last_fight_at']) - diff_delta)
-        participant.last_fight_at = (dt.fromisoformat(request.form['last_fight_at']) - diff_delta)
+        if request.form['last_fight_at'] == '':
+            participant.last_fight_at = None
+        else:
+            participant.last_fight_at = (dt.fromisoformat(request.form['last_fight_at']) - diff_delta)
 
         db.session.commit()
-
-        print(participant.last_fight_at)
 
         saved_participant = participant.id
 


### PR DESCRIPTION
## Inhalt

Diese PR behebt ein Probleme, aufgrund dessen die Parameter-Tabelle nicht funktioniert, wenn noch kein `last_fight_at`-Wert gesetzt worden ist (insb., weil d. betroffene TN noch nicht aufgerufen worden ist)

## Relevante Issues

n. n.

## Release Notes

n. n. (Problem wurde im gleichen Release eingeführt)

## Anmerkungen und Implementierungsdetails

n. n.