### PR TITLE
Einstellung zum Auskämpfen von 3./5. Platz (d.h. 3. vs. 4. bzw. 5. vs. 6 Platz)

### DIFF
--- a/event_setting_defaults.txt
+++ b/event_setting_defaults.txt
@@ -7,3 +7,5 @@ write_activity_log: True
 use_association_instead_of_club: False
 proximity_placement.hide_name: False
 proximity_placement.hide_club: False
+place.differentiate-better.third: False
+place.differentiate-better.fifth: False

--- a/webapp/helpers/list_helper.py
+++ b/webapp/helpers/list_helper.py
@@ -76,7 +76,8 @@ def dump_list(list, group):
                 if plm == 3 and list.has_option("differentiate-better.third"):
                     if list.get_fourth() == fighter:
                         local_plm = 4
-                elif plm == 5 and list.has_option("differentiate-better.fifth"):
+
+                if plm == 5 and list.has_option("differentiate-better.fifth"):
                     if list.get_sixth() == fighter:
                         local_plm = 6
 

--- a/webapp/helpers/list_helper.py
+++ b/webapp/helpers/list_helper.py
@@ -41,6 +41,12 @@ def load_list(group):
 
     list.import_struct(struct)
 
+    if group.event.setting('place.differentiate-better.third', False):
+        list.set_option("differentiate-better.third")
+
+    if group.event.setting('place.differentiate-better.fifth', False):
+        list.set_option("differentiate-better.fifth")
+
     return list
 
 def dump_list(list, group):
@@ -65,10 +71,10 @@ def dump_list(list, group):
 
                 local_plm = plm
 
-                if plm == 3 and group.event.setting('place.differentiate-better.third', False):
+                if plm == 3 and list.has_option("differentiate-better.third"):
                     if list.get_fourth() == fighter:
                         local_plm = 4
-                elif plm == 5 and group.event.setting('place.differentiate-better.fifth', False):
+                elif plm == 5 and list.has_option("differentiate-better.fifth"):
                     if list.get_sixth() == fighter:
                         local_plm = 6
 

--- a/webapp/helpers/list_helper.py
+++ b/webapp/helpers/list_helper.py
@@ -9,10 +9,12 @@ def load_list(group):
     list_cls = list_type.list_class()
 
     list = list_cls()
+
     struct = {
         'fighters': [],
         'matches': {},
-        'playoff_matches': {}
+        'playoff_matches': {},
+        'options': []
     }
 
     if group.random_seed:
@@ -39,13 +41,13 @@ def load_list(group):
             else:
                 struct['playoff_matches'][match.listslib_match_id] = match.get_result()[1]._make_list_result()
 
-    list.import_struct(struct)
-
     if group.event.setting('place.differentiate-better.third', False):
-        list.set_option("differentiate-better.third")
+        struct['options'].append("differentiate-better.third")
 
     if group.event.setting('place.differentiate-better.fifth', False):
-        list.set_option("differentiate-better.fifth")
+        struct['options'].append("differentiate-better.fifth")
+
+    list.import_struct(struct)
 
     return list
 

--- a/webapp/helpers/list_helper.py
+++ b/webapp/helpers/list_helper.py
@@ -63,8 +63,17 @@ def dump_list(list, group):
             for fighter in data:
                 if fighter == BlankFighter or fighter is None: continue
 
+                local_plm = plm
+
+                if plm == 3 and group.event.setting('place.differentiate-better.third', False):
+                    if list.get_fourth() == fighter:
+                        local_plm = 4
+                elif plm == 5 and group.event.setting('place.differentiate-better.fifth', False):
+                    if list.get_sixth() == fighter:
+                        local_plm = 6
+
                 participant = Participant.query.filter_by(id=fighter.get_id()).one()
-                participant.final_placement = plm
+                participant.final_placement = local_plm
 
     if group.random_seed is None:
         group.random_seed = list._random_seed

--- a/webapp/listslib/list.py
+++ b/webapp/listslib/list.py
@@ -16,6 +16,12 @@ class List:
 
     def __init__(self):
         self.meta.init(self)
+
+    def set_option(self, opt):
+        self.meta.set_option(self, opt)
+
+    def has_option(self, opt):
+        return self.meta.has_option(self, opt)
     
     def alloc(self, player):
         self.meta.alloc(self, player)

--- a/webapp/listslib/list.py
+++ b/webapp/listslib/list.py
@@ -44,8 +44,14 @@ class List:
     def get_third(self):
         return self.meta.get_third(self)
     
+    def get_fourth(self):
+        return self.meta.get_fourth(self)
+    
     def get_fifth(self):
         return self.meta.get_fifth(self)
+    
+    def get_sixth(self):
+        return self.meta.get_sixth(self)
     
     def import_struct(self, struct):
         return self.meta.import_struct(self, struct)

--- a/webapp/listslib/list_new_renderer.py
+++ b/webapp/listslib/list_new_renderer.py
@@ -104,9 +104,15 @@ class ListRenderer:
                 elif fighter in self.list._score_deductions['results']['second']:
                     return '2.'
                 elif fighter in self.list._score_deductions['results']['third']:
-                    return '3.'
+                    if self.list.has_option("differentiate-better.third") and self.list.get_fourth() == fighter:
+                        return '4.'
+                    else:
+                        return '3.'
                 elif fighter in self.list._score_deductions['results']['fifth']:
-                    return '5.'
+                    if self.list.has_option("differentiate-better.fifth") and self.list.get_sixth() == fighter:
+                        return '6.'
+                    else:
+                        return '5.'
                 else:
                     return ''
             else:

--- a/webapp/listslib/metalist.py
+++ b/webapp/listslib/metalist.py
@@ -919,6 +919,7 @@ class MetaList:
             if self.has_option(obj, 'differentiate-better.fifth') and not self._results_are_ordered['fifth']:
                 if 'resolve_5' not in self._playoff_match_ids:
                     self._playoff_match_ids.append('resolve_5')
+
                 self._matches['resolve_5'] = {
                     'white': fighter_refs[0],
                     'blue': fighter_refs[1],
@@ -1181,6 +1182,11 @@ class MetaList:
             po_match = self.get_match_by_id(obj, po_match_id)
             po_match.set_result(po_match_result)
             self.enter_results(obj, po_match_result)
+
+            # Better be safe than sorry, get info schedule and run score after every
+            # match has been entered, so that resolv-matches can be added possibly
+            self.get_schedule(obj, True)
+            self.score(obj)
         
         self.get_schedule(obj, False)
         self.score(obj)

--- a/webapp/listslib/metalist.py
+++ b/webapp/listslib/metalist.py
@@ -286,6 +286,14 @@ class MetaList:
     """
     def __load_score_rules(self):
         self._score_rules = []
+        self._results_are_ordered = {
+            'third': False,
+            'fifth': False
+        }
+
+        if (rao := self._com.find('meta/results-are-ordered')):
+            self._results_are_ordered['third'] = rao.attrib['third'] == 'true'
+            self._results_are_ordered['fifth'] = rao.attrib['fifth'] == 'true'
 
         for rule in self._com.findall('rules/score/*'):
             cmd = rule.tag
@@ -1032,6 +1040,25 @@ class MetaList:
         return obj._score_deductions['results']['third']
 
     """
+        get_fourth(obj)
+
+        tries to get fourth if possible
+    """
+    def get_fourth(self, obj):
+        assert obj._score_complete, \
+            "placements not available until full score evaluation"
+
+        if not 'third' in obj._score_deductions['results']:
+            return BlankFighter
+        
+        if self._results_are_ordered:
+            return self.get_third(obj)[1]
+
+        # TODO:
+
+        return BlankFighter
+
+    """
         get_fifth(obj)
 
         materially equivalent to get_third, except the fighter(s) placed in the 'fifth' slot is
@@ -1045,6 +1072,25 @@ class MetaList:
             return (BlankFighter, BlankFighter)
 
         return obj._score_deductions['results']['fifth']
+
+    """
+        get_sixth(obj)
+
+        tries to get fourth if possible
+    """
+    def get_sixth(self, obj):
+        assert obj._score_complete, \
+            "placements not available until full score evaluation"
+
+        if not 'third' in obj._score_deductions['results']:
+            return BlankFighter
+        
+        if self._results_are_ordered:
+            return self.get_fifth(obj)[1]
+
+        # TODO:
+
+        return BlankFighter
     
 
     def get_included_templates(self, obj):

--- a/webapp/listslib/metalist.py
+++ b/webapp/listslib/metalist.py
@@ -1089,15 +1089,13 @@ class MetaList:
         if not 'third' in obj._score_deductions['results']:
             return BlankFighter
         
-        if self._results_are_ordered:
+        if self._results_are_ordered['third']:
             third = self.get_third(obj)
             if len(third) == 2:
                 return third[1]
             return BlankFighter
 
-        # TODO:
-
-        return BlankFighter
+        return self._evaluate_fighter_ref(obj, {'loser': 'resolve_3'})
 
     """
         get_fifth(obj)
@@ -1126,15 +1124,13 @@ class MetaList:
         if not 'third' in obj._score_deductions['results']:
             return BlankFighter
         
-        if self._results_are_ordered:
+        if self._results_are_ordered['fifth']:
             fifth = self.get_fifth(obj)
             if len(fifth) == 2:
                 return fifth[1]
             return BlankFighter
 
-        # TODO:
-
-        return BlankFighter
+        return self._evaluate_fighter_ref(obj, {'loser': 'resolve_5'})
     
 
     def get_included_templates(self, obj):

--- a/webapp/listslib/metalist.py
+++ b/webapp/listslib/metalist.py
@@ -1052,7 +1052,10 @@ class MetaList:
             return BlankFighter
         
         if self._results_are_ordered:
-            return self.get_third(obj)[1]
+            third = self.get_third(obj)
+            if len(third) == 2:
+                return third[1]
+            return BlankFighter
 
         # TODO:
 
@@ -1086,7 +1089,10 @@ class MetaList:
             return BlankFighter
         
         if self._results_are_ordered:
-            return self.get_fifth(obj)[1]
+            fifth = self.get_fifth(obj)
+            if len(fifth) == 2:
+                return fifth[1]
+            return BlankFighter
 
         # TODO:
 

--- a/webapp/listslib/metalist.py
+++ b/webapp/listslib/metalist.py
@@ -601,8 +601,10 @@ class MetaList:
             
             expected_placement = ref['placed'] - 1
 
+            index = 0 if not 'index' in ref else ref['index']
+
             if len(obj._score_deductions['calced'][scope]['order']) > expected_placement:
-                return obj._score_deductions['calced'][scope]['order'][expected_placement][0]
+                return obj._score_deductions['calced'][scope]['order'][expected_placement][index]
             else:
                 # no fighter with that placement, possibly because this list is not full
                 return None
@@ -1101,8 +1103,15 @@ class MetaList:
     
 
     def get_included_templates(self, obj):
-        return self._included_templates
-    
+        templates = self._included_templates
+
+        if self.has_option(obj, 'differentiate-better.third') and not self._results_are_ordered['third']:
+            templates.append('resolve_3')
+
+        if self.has_option(obj, 'differentiate-better.fifth') and not self._results_are_ordered['fifth']:
+            templates.append('resolve_5')
+
+        return templates
 
     """
         import_struct(self, obj, struct)

--- a/webapp/listslib/metalist.py
+++ b/webapp/listslib/metalist.py
@@ -473,6 +473,7 @@ class MetaList:
         }
         obj._playoff_data = {}
         obj._random_seed = random.randint(1, 100000)
+        obj._options = []
 
     """
         alloc(obj, Player)
@@ -1171,3 +1172,10 @@ class MetaList:
 
     def is_playoff(self, obj, match_id):
         return match_id in self._playoff_match_ids
+    
+    def set_option(self, obj, option):
+        if option not in obj._options:
+            obj._options.append(option)
+
+    def has_option(self, obj, option):
+        return option in obj._options

--- a/webapp/listslib/rulesets/bestof3.xml
+++ b/webapp/listslib/rulesets/bestof3.xml
@@ -5,6 +5,7 @@
         <require>
             <exact of="2" />
         </require>
+        <results-are-ordered third-place="true" fifth-place="true" />
     </meta>
 
     <rules>

--- a/webapp/listslib/rulesets/doublepool8.xml
+++ b/webapp/listslib/rulesets/doublepool8.xml
@@ -6,7 +6,6 @@
             <min of="5" />
             <max of="8" />
         </require>
-        <results-are-ordered third-place="true" fifth-place="false" />
     </meta>
 
     <rules>

--- a/webapp/listslib/rulesets/doublepool8.xml
+++ b/webapp/listslib/rulesets/doublepool8.xml
@@ -6,6 +6,7 @@
             <min of="5" />
             <max of="8" />
         </require>
+        <results-are-ordered third-place="true" fifth-place="false" />
     </meta>
 
     <rules>

--- a/webapp/listslib/rulesets/pool2.xml
+++ b/webapp/listslib/rulesets/pool2.xml
@@ -5,6 +5,7 @@
         <require>
             <exact of="2" />
         </require>
+        <results-are-ordered third-place="true" fifth-place="true" />
     </meta>
 
     <rules>

--- a/webapp/listslib/rulesets/pool3.xml
+++ b/webapp/listslib/rulesets/pool3.xml
@@ -5,6 +5,7 @@
         <require>
             <exact of="3" />
         </require>
+        <results-are-ordered third-place="true" fifth-place="true" />
     </meta>
 
     <rules>

--- a/webapp/listslib/rulesets/pool4.xml
+++ b/webapp/listslib/rulesets/pool4.xml
@@ -5,6 +5,7 @@
         <require>
             <exact of="4" />
         </require>
+        <results-are-ordered third-place="true" fifth-place="true" />
     </meta>
 
     <rules>

--- a/webapp/listslib/rulesets/pool5.xml
+++ b/webapp/listslib/rulesets/pool5.xml
@@ -5,6 +5,7 @@
         <require>
             <exact of="5" />
         </require>
+        <results-are-ordered third-place="true" fifth-place="true" />
     </meta>
 
     <rules>

--- a/webapp/listslib/rulesets/single.xml
+++ b/webapp/listslib/rulesets/single.xml
@@ -5,6 +5,7 @@
         <require>
             <exact of="1" />
         </require>
+        <results-are-ordered third-place="true" fifth-place="true" />
     </meta>
 
     <rules>

--- a/webapp/listslib/templates/resolve_3.html
+++ b/webapp/listslib/templates/resolve_3.html
@@ -1,0 +1,26 @@
+<section class="tlist-section">
+    <h2>Kampf um Platz 3</h2>
+
+    <div class="tlist-ko">
+        <table class="tlist-pool-table">
+            <tbody>
+                <tr>
+                    <td class="tlist-pool-table-placement">3a</td>
+                    <td class="tlist-ko-line">%%fname:{"placed": 3, "index": 0}%%</td>
+                    <td class="tlist-ko-matchno-skip"></td>
+                </tr>
+                <tr>
+                    <td class="tlist-ko-matchno-skip"></td>
+                    <td class="tlist-ko-line-skip"></td>
+                    <td class="tlist-ko-matchno" rowspan="2">i.</td>
+                    <td class="tlist-ko-line tlist-ko-line-winner" data-placement="3">%%fname:{"winner": "resolve_3"}%%</td>
+                </tr>
+                <tr>
+                    <td class="tlist-pool-table-placement">3b</td>
+                    <td class="tlist-ko-line">%%fname:{"placed": 3, "index": 1}%%</td>
+                    <td class="tlist-ko-matchno-skip"></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</section>

--- a/webapp/listslib/templates/resolve_3.html
+++ b/webapp/listslib/templates/resolve_3.html
@@ -6,7 +6,7 @@
             <tbody>
                 <tr>
                     <td class="tlist-pool-table-placement">3a</td>
-                    <td class="tlist-ko-line">%%fname:{"placed": 3, "index": 0}%%</td>
+                    <td class="tlist-ko-line">%%fname:{"final_placed": "third", "index": 0}%%</td>
                     <td class="tlist-ko-matchno-skip"></td>
                 </tr>
                 <tr>
@@ -17,7 +17,7 @@
                 </tr>
                 <tr>
                     <td class="tlist-pool-table-placement">3b</td>
-                    <td class="tlist-ko-line">%%fname:{"placed": 3, "index": 1}%%</td>
+                    <td class="tlist-ko-line">%%fname:{"final_placed": "third", "index": 1}%%</td>
                     <td class="tlist-ko-matchno-skip"></td>
                 </tr>
             </tbody>

--- a/webapp/listslib/templates/resolve_5.html
+++ b/webapp/listslib/templates/resolve_5.html
@@ -1,0 +1,26 @@
+<section class="tlist-section">
+    <h2>Kampf um Platz 5</h2>
+
+    <div class="tlist-ko">
+        <table class="tlist-pool-table">
+            <tbody>
+                <tr>
+                    <td class="tlist-pool-table-placement">5a</td>
+                    <td class="tlist-ko-line">%%fname:{"placed": 5, "index": 0}%%</td>
+                    <td class="tlist-ko-matchno-skip"></td>
+                </tr>
+                <tr>
+                    <td class="tlist-ko-matchno-skip"></td>
+                    <td class="tlist-ko-line-skip"></td>
+                    <td class="tlist-ko-matchno" rowspan="2">i.</td>
+                    <td class="tlist-ko-line tlist-ko-line-winner" data-placement="5">%%fname:{"winner": "resolve_5"}%%</td>
+                </tr>
+                <tr>
+                    <td class="tlist-pool-table-placement">5b</td>
+                    <td class="tlist-ko-line">%%fname:{"placed": 5, "index": 1}%%</td>
+                    <td class="tlist-ko-matchno-skip"></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</section>

--- a/webapp/listslib/templates/resolve_5.html
+++ b/webapp/listslib/templates/resolve_5.html
@@ -6,7 +6,7 @@
             <tbody>
                 <tr>
                     <td class="tlist-pool-table-placement">5a</td>
-                    <td class="tlist-ko-line">%%fname:{"placed": 5, "index": 0}%%</td>
+                    <td class="tlist-ko-line">%%fname:{"final_placed": "fifth", "index": 0}%%</td>
                     <td class="tlist-ko-matchno-skip"></td>
                 </tr>
                 <tr>
@@ -17,7 +17,7 @@
                 </tr>
                 <tr>
                     <td class="tlist-pool-table-placement">5b</td>
-                    <td class="tlist-ko-line">%%fname:{"placed": 5, "index": 1}%%</td>
+                    <td class="tlist-ko-line">%%fname:{"final_placed": "fifth", "index": 1}%%</td>
                     <td class="tlist-ko-matchno-skip"></td>
                 </tr>
             </tbody>

--- a/webapp/templates/event-manager/config.html
+++ b/webapp/templates/event-manager/config.html
@@ -60,6 +60,10 @@
             {{ form.FormCheck(id='proxplace_hide_name', name='proxplace_hide_name', label='TN-Name bei Einteilung nach gewichtsnahen Gruppen ausblenden', checked=g.event.setting('proximity_placement.hide_name', False)) }}
 
             {{ form.FormCheck(id='proxplace_hide_club', name='proxplace_hide_club', label='Verein bzw. Verband bei Einteilung nach gewichtsnahen Gruppen ausblenden', checked=g.event.setting('proximity_placement.hide_club', False)) }}
+
+            {{ form.FormCheck(id='differentiate_better_third_place', name='differentiate_better_third_place', label='Dritten Platz ggf. auskämpfen (3. vs. 4. Platz)', checked=g.event.setting('place.differentiate-better.third', False)) }}
+
+            {{ form.FormCheck(id='differentiate_better_fifth_place', name='differentiate_better_fifth_place', label='Fünften Platz ggf. auskämpfen (5. vs. 6. Platz)', checked=g.event.setting('place.differentiate-better.fifth', False)) }}
         {% endcall %}
         {% call cards.CardBody() %}
             {{ form.Label(for_id='sbid', text="Scoreboard") }}

--- a/webapp/views/event_manager.py
+++ b/webapp/views/event_manager.py
@@ -140,6 +140,9 @@ def save_config():
         g.event.save_setting('proximity_placement.hide_name', 'proxplace_hide_name' in request.form)
         g.event.save_setting('proximity_placement.hide_club', 'proxplace_hide_club' in request.form)
 
+        g.event.save_setting('place.differentiate-better.third', 'differentiate_better_third_place' in request.form)
+        g.event.save_setting('place.differentiate-better.fifth', 'differentiate_better_fifth_place' in request.form)
+
         g.event.scoreboard_ruleset = ScoreboardRuleset.query.get(request.form['sbid'])
         db.session.commit()
 

--- a/webapp/views/mod_results.py
+++ b/webapp/views/mod_results.py
@@ -77,7 +77,12 @@ def team_rankings():
                 if team not in teams:
                     teams[team] = {1:0, 2:0, 3:0, 5:0, 7:0}
                 
-                teams[team][participant.final_placement] += 1
+                if participant.final_placement == 4:
+                    teams[team][3] += 1
+                elif participant.final_placement == 6:
+                    teams[team][5] += 1
+                else:
+                    teams[team][participant.final_placement] += 1
 
         if len(teams.keys()):
             teams = dict(sorted(teams.items(), key=lambda t: (t[1][1], t[1][2], t[1][3], t[1][5]), reverse=True))


### PR DESCRIPTION
## Inhalt

Diese PR fügt ein Einstellung hinzu, um die 3. bzw. 5. Plätze auszukämpfen, d. h. zu einem 4. bzw. 6. Platz zu unterscheiden. Bei Listen, die (insoweit) eine vollständige Reihung vornehmen, d. h. bei Pool-Listen, finden keine zusätzlichen Kämpfe statt, sondern es wird einfach nach der Ergebnisreihung unterschieden. Bei allen anderen Listen wird am Ende ein Zusatzkampf zwischen den beiden dritt- bzw. fünftplatzierten TN eingefügt, um die Unterscheidung zu ermöglichen.

## Relevante Issues

- resolves #7 

## Release Notes

```
- Ausgekämpfte dritte und fünfte Plätze (#7 -> #41)
     - Es wurden Einstellungen zur Veranstaltungskonfiguration hinzugefügt, um das Auskämpfen von Platz 3 bzw. 5 ein- oder auszuschalten.
     - Soweit die Liste bereits zwischen Platz 3 und 4 bzw. Platz 5 und 6 unterscheiden kann, finden keine weiteren Kämpfe statt.
     - Andernfalls wird ein Zusatzkampf eingefügt, um eine Unterscheidung zu ermöglichen.
```

## Anmerkungen und Implementierungsdetails

n. n.