### PR TITLE
Fehlerbehebung bzgl. des Datenbank-Pool-Recyclings

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -16,6 +16,7 @@ app.config['BRAND_NAME'] = "TATAMI 2025"
 # SQLAlchemy and Migrate
 app.config['SQLALCHEMY_DATABASE_URI'] = SETTINGS['SQL_URL']
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {'pool_recycle': 280}  # prevent timeouts/500 errors on prod
 db.init_app(app)
 migrate = Migrate(app, db)
 


### PR DESCRIPTION
## Inhalt

Diese PR behebt, dass manchmal - insbesondere bei Produktivinstanzen - beim ersten Aufruf von TATAMI nach einiger Zeit ein 500 Server-Fehler angezeigt wude, da die Datenbank-Verbindungen abgelaufen waren, indem eine Pool Recycling-Regel eingeführt wird.

## Relevante Issues

n. n.

## Release Notes

```
- Fehlerbehebung bzgl. des Datenbank-Pool-Recyclings (-> #43)
     - Ein Problem wurde behoben, dass manchmal - insbesondere bei Produktivinstanzen - beim ersten Aufruf von TATAMI nach einiger Zeit ein 500 Server-Fehler angezeigt wude, da die Datenbank-Verbindungen abgelaufen waren.
```

## Anmerkungen und Implementierungsdetails

n. n.