### PR TITLE
Verbesserte TN-Suche bei Akkreditierung und Waage

### DIFF
--- a/webapp/templates/mod_registration/index.html
+++ b/webapp/templates/mod_registration/index.html
@@ -3,6 +3,7 @@
 {%- import "components/buttons.html" as buttons -%}
 {%- import "components/form.html" as form -%}
 {%- import "components/datasets.html" as datasets -%}
+{%- import "components/alerts.html" as alerts -%}
 
 {% extends "layouts/application.html" %}
 {% block title %}Anmeldung{% endblock %}
@@ -30,6 +31,23 @@
             </form>
         {% endcall %}
     {% endcall %}
+
+    {% if the_one_registration %}
+        {% call cards.Card() %}
+            {% call cards.CardBody(class="py-1") %}
+                {% call layout.Grid(class="align-center") %}
+                    {% call layout.GridColumn(span="") %}Es wurde folgender/n TN mit einem exakten Treffer gefunden: <strong>{{ the_one_registration.first_name }} {{ the_one_registration.last_name }}</strong>{% endcall %}
+                    {% call layout.GridColumn(span="auto") %}
+                        {% if not the_one_registration.registered %}
+                            {{ buttons.SecondaryButton(text="Akkreditieren", href=url_for('mod_registrations.confirm', event=g.event.slug, id=the_one_registration.id)) }}
+                        {% else %}
+                            {{ buttons.DangerButton(text="Zurücknehmen", href=url_for('mod_registrations.unconfirm', event=g.event.slug, id=the_one_registration.id, query=quarg)) }}
+                        {% endif %}
+                    {% endcall %}
+                {% endcall %}
+            {% endcall %}
+        {% endcall %}
+    {% endif %}
 
     {% call datasets.Dataset(size="medium") %}
         {% call datasets.Table() %}
@@ -64,7 +82,7 @@
                                 {{ buttons.SecondaryButton(text="Akkreditieren", href=url_for('mod_registrations.confirm', event=g.event.slug, id=reg.id, query=quarg), inline=True) }}
                             {% else %}
                                 {{ buttons.SubtleButton(text="Zurücknehmen", href=url_for('mod_registrations.unconfirm', event=g.event.slug, id=reg.id, query=quarg), inline=True) }}
-                            {% endif %}                            
+                            {% endif %}
                         {% endcall %}
                     {% endcall %}
                 {% endfor %}

--- a/webapp/templates/mod_weighin/index.html
+++ b/webapp/templates/mod_weighin/index.html
@@ -31,6 +31,23 @@
         {% endcall %}
     {% endcall %}
 
+    {% if the_one_registration %}
+        {% call cards.Card() %}
+            {% call cards.CardBody(class="py-1") %}
+                {% call layout.Grid(class="align-center") %}
+                    {% call layout.GridColumn(span="") %}Es wurde folgender/n TN mit einem exakten Treffer gefunden: <strong>{{ the_one_registration.first_name }} {{ the_one_registration.last_name }}</strong>{% endcall %}
+                    {% call layout.GridColumn(span="auto") %}
+                        {% if not the_one_registration.weighed_in %}
+                            {{ buttons.SecondaryButton(text="Einwiegen", href=url_for('mod_weighin.for_participant', event=g.event.slug, id=the_one_registration.id)) }}
+                        {% else %}
+                            {{ buttons.DangerButton(text="Zurücknehmen", href=url_for('mod_weighin.correct_for_participant', event=g.event.slug, id=the_one_registration.id, query=quarg)) }}
+                        {% endif %}
+                    {% endcall %}
+                {% endcall %}
+            {% endcall %}
+        {% endcall %}
+    {% endif %}
+
     {% call datasets.Dataset(size="medium") %}
         {% call datasets.Table() %}
             {% call datasets.TableHead() %}
@@ -64,7 +81,7 @@
                                 {{ buttons.SecondaryButton(text="Einwiegen", href=url_for('mod_weighin.for_participant', event=g.event.slug, id=reg.id, query=quarg), inline=True) }}
                             {% else %}
                                 {{ buttons.SubtleButton(text="Zurücknehmen", href=url_for('mod_weighin.correct_for_participant', event=g.event.slug, id=reg.id, query=quarg), inline=True) }}
-                            {% endif %}                      
+                            {% endif %}
                         {% endcall %}
                     {% endcall %}
                 {% endfor %}

--- a/webapp/views/mod_registrations.py
+++ b/webapp/views/mod_registrations.py
@@ -20,6 +20,7 @@ def index():
     
     query = g.event.registrations.filter_by(confirmed=True)
     quarg = None
+    the_one_registration = None
 
     if "query" in request.values:
         query = query.filter(Registration.last_name.ilike(f"{request.values['query']}%") |
@@ -27,9 +28,21 @@ def index():
                              Registration.club.ilike(f"{request.values['query']}%"))
         quarg = request.values['query']
 
-    query = query.order_by('registered', 'last_name', 'first_name').all()
+    query = query.order_by('registered', 'last_name', 'first_name')
+
+    if quarg:
+        if query.count() == 1:
+            the_one_registration = query.one()
+        
+        elif query.filter_by(external_id=quarg).count() == 1:
+            the_one_registration = query.filter_by(external_id=quarg).one()
+        
+        elif query.filter_by(last_name=quarg).count() == 1:
+            the_one_registration = query.filter_by(last_name=quarg).one()
+
+    query = query.all()
     
-    return render_template("mod_registration/index.html", query=query, quarg=quarg)
+    return render_template("mod_registration/index.html", query=query, quarg=quarg, the_one_registration=the_one_registration)
 
 
 @mod_registrations_view.route('/confirm/<id>')

--- a/webapp/views/mod_registrations.py
+++ b/webapp/views/mod_registrations.py
@@ -25,7 +25,9 @@ def index():
     if "query" in request.values:
         query = query.filter(Registration.last_name.ilike(f"{request.values['query']}%") |
                              Registration.external_id.ilike(f"{request.values['query']}%") |
-                             Registration.club.ilike(f"{request.values['query']}%"))
+                             Registration.club.ilike(f"{request.values['query']}%") |
+                             Registration.club.ilike(f"% {request.values['query']}%") |
+                             Registration.club.ilike(f"%-{request.values['query']}%"))
         quarg = request.values['query']
 
     query = query.order_by('registered', 'last_name', 'first_name')

--- a/webapp/views/mod_weighin.py
+++ b/webapp/views/mod_weighin.py
@@ -25,7 +25,9 @@ def index():
     if "query" in request.values:
         query = query.filter(Registration.last_name.ilike(f"{request.values['query']}%") |
                              Registration.external_id.ilike(f"{request.values['query']}%") |
-                             Registration.club.ilike(f"{request.values['query']}%"))
+                             Registration.club.ilike(f"{request.values['query']}%") |
+                             Registration.club.ilike(f"% {request.values['query']}%") |
+                             Registration.club.ilike(f"%-{request.values['query']}%"))
         quarg = request.values['query']
 
     query = query.order_by('weighed_in', 'registered', 'last_name', 'first_name')


### PR DESCRIPTION
## Inhalt

Diese PR verbessert die TN-Suche im Akkreditierungs- und im Waagemodul mit zwei Änderungen:

- ergibt die Sucheingabe, dass nur ein TN ausgewählt worden ist oder gibt es bzgl. Nachnamen oder Externer ID einen *eindeutigen* Treffer, so wird ein Block über der TN-Tabelle angezeigt, der diese/n TN vorschlägt und die jeweiligen Optionen anbietet:
    
    ![](https://github.com/user-attachments/assets/b0c59700-9844-4148-98c5-9795b74a8884)
    
- Vereine können nun auch nach einem wesentlichen Wortinnenbestandteil durchsucht werden, wenn der Bestandteil im Vereinsnamen nach einem Leerzeichen oder einem Minus folgt. So ist es nun bspw. möglich, nach einem - fiktiven - "JC Tatami e.V." zu suchen, indem man nur "Tatami" eingibt.

## Relevante Issues

n. n.

## Release Notes

```
- Verbesserte TN-Suche bei Akkreditierung und Waage (-> #44)
     - Bei exakten Treffern bzgl. Name oder externer ID wird nun die/der gefundene TN noch einmal hervorgehoben angezeigt
     - Vereinsnamen können nun nach Wortinnenbestandteilen durchsuchen, wenn diese einem Leerzeichen oder einem Minus folgen
```

## Anmerkungen und Implementierungsdetails

n. n.