### PR TITLE
Verbesserungen beim Einteilungsmodul

### DIFF
--- a/webapp/static/application/proximity_helper.js
+++ b/webapp/static/application/proximity_helper.js
@@ -95,8 +95,8 @@ let updateHelperWindow = (hw, data) => {
     groupDataString = groupDataString.trim()
 
     hw.innerText = ("Anzahl der Gruppen:  " + String(numberOfGroups).padStart(4) + "\n" +
-                    "Max. Gruppengröße:   " + String(maxGroupUserCount).padStart(4) + "\n" +
-                    "Übersprungene TN:    " + String(ignoredItems).padStart(4) + "\n" +
+                    "Max. Gruppengröße:   " + String(maxGroupUserCount).padStart(4) + " TN\n" +
+                    "Übersprungene TN:    " + String(ignoredItems).padStart(4) + " TN\n" +
                     "Max. Differenz (kg): " + String(maxGroupWeightDiff).padStart(4) + " kg\n" +
                     "Max. Differenz (%):  " + String(maxGroupWeightDiffPerc).padStart(4) + " %\n\n") + groupDataString
 }

--- a/webapp/static/application/proximity_helper.js
+++ b/webapp/static/application/proximity_helper.js
@@ -1,16 +1,21 @@
 let createHelperWindow = () => {
     let hw = document.createElement("div")
     document.body.appendChild(hw)
-    hw.innerText = "loading proximity helper..."
+    hw.innerText = "Helfer lädt…"
     hw.style.position = "fixed"
-    hw.style.bottom = "1em"
+    hw.style.bottom = "0.5em"
+    hw.style.right = "0.5em"
+    hw.style.padding = "1em"
     hw.style.fontFamily = "Reddit Mono"
+    hw.style.fontSize = "0.95em"
     hw.style.whiteSpace = "pre-wrap"
-    hw.style.right = "1em"
-    hw.style.color = "red"
+    hw.style.color = "white"
+    hw.style.backgroundColor = "#36363a"
+    hw.style.borderTop = "0.5em solid teal"
     hw.style.userSelect = "none"
-    hw.style.pointerEvents = "none"
-    hw.style.width = "275px"
+    hw.style.width = "300px"
+    hw.style.maxHeight = "70vh"
+    hw.style.overflowY = "auto"
 
     return hw
 }

--- a/webapp/static/application/proximity_helper.js
+++ b/webapp/static/application/proximity_helper.js
@@ -1,0 +1,109 @@
+let createHelperWindow = () => {
+    let hw = document.createElement("div")
+    document.body.appendChild(hw)
+    hw.innerText = "loading proximity helper..."
+    hw.style.position = "fixed"
+    hw.style.bottom = "1em"
+    hw.style.fontFamily = "Reddit Mono"
+    hw.style.whiteSpace = "pre-wrap"
+    hw.style.right = "1em"
+    hw.style.color = "red"
+    hw.style.userSelect = "none"
+    hw.style.pointerEvents = "none"
+    hw.style.width = "275px"
+
+    return hw
+}
+
+let loadProximityData = () => {
+    let seg = document.querySelector(".segmentation")
+    let data = []
+
+    for (const segChild of seg.childNodes) {
+        // skip non-html elements
+        if (segChild.nodeType != 1) continue
+
+        if(segChild.classList.contains("segmentation-item")) {
+            data.push({ "type": "item",
+                "checkbox": segChild.querySelector("input[type=checkbox]"),
+                "weight": Number.parseFloat(segChild.querySelector("strong").innerText) })
+        } else if(segChild.classList.contains("segmentation-control")) {
+            data.push({ "type": "control",
+                "checkbox": segChild.querySelector("input[type=checkbox]") })
+        }
+    }
+
+    data.push({ "type": "final" })
+
+    return data
+}
+
+let updateHelperWindow = (hw, data) => {
+    numberOfGroups = 0
+    maxGroupUserCount = 0
+    maxGroupWeightDiff = 0
+    maxGroupWeightDiffPerc = 0
+    ignoredItems = 0
+
+    groupData = []
+
+    currentGroupUserCount = 0
+    currentGroupInitialWeight = null
+    lastWeight = 0
+
+    for (const element of data) {
+        if ((element.type == "control" && element.checkbox.checked) || element.type == "final") {
+            if ((lastWeight - currentGroupInitialWeight) > maxGroupWeightDiff)
+                maxGroupWeightDiff = lastWeight - currentGroupInitialWeight
+
+            if ((lastWeight / currentGroupInitialWeight) > maxGroupWeightDiffPerc)
+                maxGroupWeightDiffPerc = lastWeight / currentGroupInitialWeight
+
+            if (currentGroupUserCount > maxGroupUserCount)
+                maxGroupUserCount = currentGroupUserCount
+
+            groupData.push([lastWeight, currentGroupUserCount])
+
+            numberOfGroups++
+            currentGroupUserCount = 0
+            currentGroupInitialWeight = null
+            lastWeight = 0
+        } else if (element.type == "item") {
+            if (!element.checkbox.checked) {
+                ignoredItems++
+                continue
+            }
+
+            currentGroupUserCount++
+            lastWeight = element.weight
+
+            if (currentGroupInitialWeight === null)
+                currentGroupInitialWeight = element.weight
+        }
+    }
+
+    maxGroupWeightDiff = maxGroupWeightDiff.toFixed(1)
+    maxGroupWeightDiffPerc = ((maxGroupWeightDiffPerc - 1.0) * 100).toFixed(1)
+
+    groupDataString = "Gruppen:\n"
+    i = 0
+
+    for (const group of groupData) {
+        groupDataString += ("" + (++i)).padStart(2) + ") -" + group[0].toFixed(1) + " kg - " + (""+group[1]).padStart(2) + " TN\n"
+    }
+    
+    groupDataString = groupDataString.trim()
+
+    hw.innerText = ("Anzahl der Gruppen:  " + String(numberOfGroups).padStart(4) + "\n" +
+                    "Max. Gruppengröße:   " + String(maxGroupUserCount).padStart(4) + "\n" +
+                    "Übersprungene TN:    " + String(ignoredItems).padStart(4) + "\n" +
+                    "Max. Differenz (kg): " + String(maxGroupWeightDiff).padStart(4) + " kg\n" +
+                    "Max. Differenz (%):  " + String(maxGroupWeightDiffPerc).padStart(4) + " %\n\n") + groupDataString
+}
+
+window.addEventListener("load", () => {
+    let hw = createHelperWindow()
+    let data = loadProximityData()
+
+    window.setInterval(updateHelperWindow, 500, hw, data)
+})

--- a/webapp/templates/mod_placement/participant/switch_placement.html
+++ b/webapp/templates/mod_placement/participant/switch_placement.html
@@ -13,7 +13,7 @@
 
     <h1>Kampfklasse {{ event_class.title }} &ndash; TN tauschen</h1>    
 
-    <form action="" method="POST">
+    <form action="?" method="POST">
         {% call cards.Card() %}
             {% call cards.CardBody() %}
                 <p class="mb-1">In der Gruppe</p>
@@ -33,7 +33,8 @@
                 {% endfor %}
             {% endcall %}
             {% call cards.CardFooter() %}
-                {{ buttons.PrimaryButton(type='submit', text='Setzen') }}
+                {{ buttons.PrimaryButton(type='submit', text='Tauschen und zurück') }}
+                {{ buttons.PrimaryButton(type='submit', text='Tauschen', attr='formaction="?stay-on-page=1"') }}
                 {{ buttons.SecondaryButton(href=url_for('mod_placement.for_class', event=g.event.slug, id=event_class.id, group=group.id), text='Abbrechen') }}
             {% endcall %}
         {% endcall %}

--- a/webapp/templates/mod_placement/registration/assign_all-proximity.html
+++ b/webapp/templates/mod_placement/registration/assign_all-proximity.html
@@ -63,3 +63,7 @@
     </form>
 {% endcall %}
 {% endblock body %}
+
+{% block custom_header %}
+<script src="{{ url_for('static', filename='application/proximity_helper.js') }}" defer></script>
+{% endblock custom_header %}

--- a/webapp/views/mod_placement.py
+++ b/webapp/views/mod_placement.py
@@ -540,7 +540,10 @@ def switch_placements(id, group_id):
                 second_participant.manually_placed = True
             
             db.session.commit()
-            return redirect(url_for('mod_placement.for_class', event=g.event.slug, id=event_class.id, group=group.id))
+
+            if "stay-on-page" not in request.values:
+                return redirect(url_for('mod_placement.for_class', event=g.event.slug, id=event_class.id,
+                                        group=group.id))
 
         else:
             flash("Wählen Sie genau zwei Positionen aus, die vertauscht werden sollen", 'danger')


### PR DESCRIPTION
## Inhalt

Diese PR enthält zwei Verbesserungen des Einteilungsmoduls:

- Die TN-Tauschen-Seite hat nun einen - wie der bisherige Submit-Knopf funktionierenden - Knopf namens "Tauschen und schließen" und einen Knopf namens "Tauschen", der die Seite nach dem Speichern offen hält.
- Im Rahmen der Einteilung gewichtsnaher Gruppen werden nun einige Status-Informationen, wie bspw. die Anzahl der Gruppen, der max. Gruppengröße und des max. Gewichtsunterschieds in kg und % sowie für jede vsstl. zu erzeugende Gruppe das Höchstgewicht und die TN-Anzahl am Rand angezeigt:

    ![](https://github.com/user-attachments/assets/c545da65-e1f3-435e-83c4-be697c5d1f20)
## Relevante Issues

n. n.

## Release Notes

```
- Verbesserungen beim Einteilungsmodul (-> #46)
     - Beim Tauschen von bereits gelosten TN gibt es nun die Möglichkeit, auf der aktuellen Seite zu bleiben, um weitere TN zu tauschen.
     - Bei der Einteilung nach gewichtsnahen Gruppen werden nun Status-Informationen, wie bspw. die Anzahl der Gruppen, der max. Gruppengröße und des max. Gewichtsunterschieds in kg und % sowie für jede vsstl. zu erzeugende Gruppe das Höchstgewicht und die TN-Anzahl am Rand angezeigt.
```

## Anmerkungen und Implementierungsdetails

n. n.
