### PR TITLE
Ps/correct relative sorting

### DIFF
--- a/webapp/helpers/list_helper.py
+++ b/webapp/helpers/list_helper.py
@@ -165,7 +165,10 @@ def _check_if_match_is_obsolete(dbmatch, listmatch):
         
         # Do not modify existing matches that have results
         # or are already scheduled, instead mark them as obsolete
-        if dbmatch.scheduled or dbmatch.has_result():
+        if dbmatch.scheduled or dbmatch.has_result() or (
+            listmatch.get_white().get_id() == '__blank' or
+            listmatch.get_blue().get_id() == '__blank'
+        ):
             dbmatch.obsolete = True
             dbmatch.scheduled = False
             dbmatch.called_up = False


### PR DESCRIPTION
## Inhalt

Diese PR fügt zwei kleine Verbesserungen/Fehlerbehebungen in die Listenbibliothek ein:

- Für die Bestimmung des Siegers einer Liste werden die TN nun vollständig korrekt sortiert, nämlich nach Nichtdisqualifikation, Siegpunkten, Unterpunkten und bei Gleichstand nach dem besseren Ergebnis bei den gemeinschaftlichen Kämpfen
- Führt eine Änderung bei den Kampfergebnissen zum Wegfall einzelner Kämpfe, wird nun nicht mehr eine Fehlermeldung ausgegeben.

## Release Notes

```
- Fehler bei der Listenbibliothek wurden behoben (-> #50)
     - Die Platzierungen in einer Liste werden nun richtig wie folgt bestimmt: Nichtdisqualifikation, Siegpunkte, Unterpunkte und bei Gleichstand: besseres Ergebnis bei den gemeinschaftlichen Kämpfen
     - Bei Änderung eines Kampfergebnisses führen wegfallende Kämpfe nicht mehr zu Fehlermeldungen.
```

## Anmerkungen und Implementierungsdetails

n. n.