### PR TITLE
Generator-Werkzeuge hinzufügen

### DIFF
--- a/webapp/helpers/list_helper.py
+++ b/webapp/helpers/list_helper.py
@@ -32,7 +32,7 @@ def load_list(group):
                 f.disqualify()
             elif participant.removed:
                 f.remove()
-            struct['fighters'].append(f)        
+            struct['fighters'].append(f)
 
     for match in group.matches.all():
         if not match.obsolete and match.has_result():

--- a/webapp/listslib/__init__.py
+++ b/webapp/listslib/__init__.py
@@ -3,6 +3,7 @@ from .metalist import *
 from .fighter import Fighter
 from .match_result import MatchResult
 from .list_new_renderer import ListRenderer
+from .empty_list_mock import EmptyListMock
 
 if __name__ == "__main__":
     # example_list = compile_list('pool2')()

--- a/webapp/listslib/empty_list_mock.py
+++ b/webapp/listslib/empty_list_mock.py
@@ -1,0 +1,22 @@
+from .list_compiler import compile_list
+from .fighter import Fighter
+
+class EmptyListMock:
+
+    def __init__(self, event_class, list_system):
+        self.event_class = event_class
+        self.list_system = list_system
+
+        self.the_list = compile_list(self.list_system.list_file)()
+
+        for n in range(self.the_list.require_max()):
+            self.the_list.alloc(Fighter(f'f{n}', '', ''))
+
+        self.assigned_to_position = None
+        self.title = ""
+
+    def get_list(self):
+        return self.the_list
+    
+    def cut_title(self):
+        return ''

--- a/webapp/templates/event-manager/devices.html
+++ b/webapp/templates/event-manager/devices.html
@@ -63,18 +63,6 @@
     {% endcall %}
 {% endcall %}
 
-<h3>Offline-Scoreboard</h3>
-
-<p>Sie können ein Offline-Scoreboard für diese Veranstaltung erzeugen und herunterladen. Das Offline-Scoreboard kann dann auch ohne Anmeldung oder Netzwerk-Verbindung verwendet werden.</p>
-
-<p>Ggf. müssen Sie Sicherheitsfunktionen deaktivieren, um das Offline-Scoreboard nutzen zu können. In Firefox müssen Sie bspw. in <a href="about:config">about:config</a> die Einstellung <code>security.fileuri.strict_origin_policy</code> deaktivieren, damit zwischen dem Controller und dem Scoreboard Daten übertragen werden können. Alternativ können Sie einen HTTP-Server verwenden, um das Offline-Scoreboard auf localhost bereitzustellen.</p>
-
-{% call alerts.WarningAlert() %}
-    <p>Diese Funktion ist bislang noch experimentell und sollte nur eingeschränkt verwendet werden.</p>
-{% endcall %}
-
-{{ buttons.SecondaryButton(href=url_for('event_manager.offline_board', event=g.event.slug), text="Scoreboard herunterladen") }}
-
 {% endblock body %}
 
 {% macro position(pos, roles, positions) %}

--- a/webapp/templates/event-manager/generators.html
+++ b/webapp/templates/event-manager/generators.html
@@ -1,0 +1,23 @@
+{%- import "components/buttons.html" as buttons -%}
+{%- import "components/layout.html" as layout -%}
+{%- import "components/alerts.html" as alerts -%}
+
+{% set event_page="generators" %}
+{% extends "layouts/event-manager.html" %}
+{% block title %}{{ g.event.title }} | Werkzeug-Downloads{% endblock %}
+{% block body %}
+<h1>Werkzeug-Downloads</h1>
+
+<h2>Offline-Scoreboard</h2>
+
+<p>Sie können ein Offline-Scoreboard für diese Veranstaltung erzeugen und herunterladen. Das Offline-Scoreboard kann dann auch ohne Anmeldung oder Netzwerk-Verbindung verwendet werden.</p>
+
+<p>Ggf. müssen Sie Sicherheitsfunktionen deaktivieren, um das Offline-Scoreboard nutzen zu können. In Firefox müssen Sie bspw. in <a href="about:config">about:config</a> die Einstellung <code>security.fileuri.strict_origin_policy</code> deaktivieren, damit zwischen dem Controller und dem Scoreboard Daten übertragen werden können. Alternativ können Sie einen HTTP-Server verwenden, um das Offline-Scoreboard auf localhost bereitzustellen.</p>
+
+{% call alerts.WarningAlert() %}
+    <p>Diese Funktion ist bislang noch experimentell und sollte nur eingeschränkt verwendet werden.</p>
+{% endcall %}
+
+{{ buttons.SecondaryButton(href=url_for('event_manager.offline_board', event=g.event.slug), text="Scoreboard herunterladen") }}
+
+{% endblock body %}

--- a/webapp/templates/event-manager/generators.html
+++ b/webapp/templates/event-manager/generators.html
@@ -1,12 +1,36 @@
 {%- import "components/buttons.html" as buttons -%}
 {%- import "components/layout.html" as layout -%}
 {%- import "components/alerts.html" as alerts -%}
+{%- import "components/datasets.html" as datasets -%}
 
 {% set event_page="generators" %}
 {% extends "layouts/event-manager.html" %}
 {% block title %}{{ g.event.title }} | Werkzeug-Downloads{% endblock %}
 {% block body %}
-<h1>Werkzeug-Downloads</h1>
+<h1>Werkzeuge</h1>
+
+<p>Hier können Sie verschiedene Werkzeuge herunterladen:</p>
+
+<h2>Listenvorlagen</h2>
+
+<p>Wählen Sie eine Kampfklasse und einen Listentyp aus:</p>
+
+{% call datasets.Dataset() %}
+    {% call datasets.Table() %}
+        {% for class in g.event.classes %}
+            {% call datasets.TableRow() %}
+                {{ datasets.TableColumn(text=class.title) }}
+                {% for lt in list_types %}
+                    {% call datasets.TableButtonsColumn() %}
+                        {% call buttons.SubtleButton(href=url_for('event_manager.generate_list', event=g.event.slug, event_class=class.id, list=lt.list_file), inline=True) %}
+                            {{ buttons.ButtonIcon(icon='download-square', label=lt.list_file) }}
+                        {% endcall %}
+                    {% endcall %}
+                {% endfor %}
+            {% endcall %}
+        {% endfor %}
+    {% endcall %}
+{% endcall %}
 
 <h2>Offline-Scoreboard</h2>
 
@@ -18,6 +42,6 @@
     <p>Diese Funktion ist bislang noch experimentell und sollte nur eingeschränkt verwendet werden.</p>
 {% endcall %}
 
-{{ buttons.SecondaryButton(href=url_for('event_manager.offline_board', event=g.event.slug), text="Scoreboard herunterladen") }}
+{{ buttons.SecondaryButton(href=url_for('event_manager.generate_offline_board', event=g.event.slug), text="Scoreboard herunterladen") }}
 
 {% endblock body %}

--- a/webapp/templates/layouts/event-manager.html
+++ b/webapp/templates/layouts/event-manager.html
@@ -34,7 +34,7 @@
                         label="Geräte- und Hallenplan", icon="network", active=event_page=='devices') }}
 
                     {{ toolbar.ToolbarMenuItem(href=url_for('event_manager.generators', event=g.event.slug),
-                        label="Downloads", icon="potion", active=event_page=='generators') }}
+                        label="Werkzeuge", icon="potion", active=event_page=='generators') }}
 
                     {# toolbar.ToolbarMenuItem(href="",
                         label="Streaming", icon="antenna", active=event_page=='streaming') #}

--- a/webapp/templates/layouts/event-manager.html
+++ b/webapp/templates/layouts/event-manager.html
@@ -33,6 +33,9 @@
                     {{ toolbar.ToolbarMenuItem(href=url_for('event_manager.devices', event=g.event.slug),
                         label="Geräte- und Hallenplan", icon="network", active=event_page=='devices') }}
 
+                    {{ toolbar.ToolbarMenuItem(href=url_for('event_manager.generators', event=g.event.slug),
+                        label="Downloads", icon="potion", active=event_page=='generators') }}
+
                     {# toolbar.ToolbarMenuItem(href="",
                         label="Streaming", icon="antenna", active=event_page=='streaming') #}
 

--- a/webapp/views/event_manager.py
+++ b/webapp/views/event_manager.py
@@ -1171,8 +1171,15 @@ def quick_sign_in():
     return redirect(url_for('event_manager.devices', event=g.event.slug))
 
 
+@eventmgr_view.route('/generator')
+@login_required
+@check_and_apply_event
+@check_is_event_supervisor
+def generators():
+    return render_template('event-manager/generators.html')
 
-@eventmgr_view.route('/offline-scoreboard')
+
+@eventmgr_view.route('/generator/offline-scoreboard')
 @login_required
 @check_and_apply_event
 @check_is_event_supervisor

--- a/webapp/views/event_manager.py
+++ b/webapp/views/event_manager.py
@@ -10,6 +10,8 @@ from ..models import db, Event, EventClass, DeviceRegistration, \
 
 from ..helpers import _get_or_create
 
+from ..listslib import ListRenderer, EmptyListMock
+
 from datetime import datetime
 import time, uuid, os, csv, io, zipfile
 
@@ -1176,14 +1178,34 @@ def quick_sign_in():
 @check_and_apply_event
 @check_is_event_supervisor
 def generators():
-    return render_template('event-manager/generators.html')
+    list_types = ListSystem.all_enabled()
+    return render_template('event-manager/generators.html', list_types=list_types)
+
+
+@eventmgr_view.route('/generator/list-<event_class>-<list>.pdf')
+@login_required
+@check_and_apply_event
+@check_is_event_supervisor
+def generate_list(event_class, list):
+    event_class = g.event.classes.filter_by(id=event_class).one_or_404()
+    list_system = ListSystem.all_enabled().filter_by(list_file=list).one_or_404()
+
+    elm = EmptyListMock(event_class=event_class, list_system=list_system)
+    ell = elm.get_list()
+    lr = ListRenderer(ell, g.event, elm, served=False)
+
+    pdf_io = io.BytesIO()
+    pdf_io.write((pdf_data := lr.render_pdf())[0])
+    pdf_io.seek(0)
+
+    return send_file(pdf_io, mimetype='application/pdf')
 
 
 @eventmgr_view.route('/generator/offline-scoreboard')
 @login_required
 @check_and_apply_event
 @check_is_event_supervisor
-def offline_board():
+def generate_offline_board():
     zip_io = io.BytesIO()
     zip_file = zipfile.ZipFile(zip_io, mode='w')
 


### PR DESCRIPTION
## Inhalt

Diese PR fügt einen neuen Werkzeug-Tab im Event Manager hinzu. Dorthin wurde die Funktion zum Download des Offline-Scoreboards (#36) verschoben, außerdem wurde dort eine neue Funktion hinzugefügt, mit denen leere Listen der verschiedenen Typen generiert und als PDF heruntergeladen werden können.

## Release Notes

```
- Herunterladen von Listenvorlagen (-> #57)
     - Im Event Manager (Werkzeug-Tab) wurde eine Funktion hinzugefügt, mit der leere Listenvorlagen für ein Event + eine Event Klasse heruntergeladen werden können und zwar von allen aktivierten Listentypen
```

## Anmerkungen und Implementierungsdetails

n. n.