### PR TITLE
Verbesserungen im Scoreboard und SB-Controller

### DIFF
--- a/webapp/helpers/schedule_helper.py
+++ b/webapp/helpers/schedule_helper.py
@@ -46,6 +46,8 @@ def do_match_schedule(mat):
 
     attempts = 2 * LIMIT_OF_FORECAST_FOR_SCHEDULE
 
+    NEXT_FIGHT_AT = 0
+
     while len(mat.scheduled_matches()) < LIMIT_OF_FORECAST_FOR_SCHEDULE:
         attempts -= 1
 
@@ -62,6 +64,10 @@ def do_match_schedule(mat):
                 # if not, if the current group's next item is a break, decrease group break counter
                 if next_match is None:
                     selected_group.list_break_count -= 1
+                else:
+                    remaining_break_time = next_match.remaining_break_time()
+                    if remaining_break_time > NEXT_FIGHT_AT:
+                        NEXT_FIGHT_AT = remaining_break_time
 
                 # clear current groups scheduled-for key and current group status
                 selected_group.currently_used = False
@@ -103,6 +109,8 @@ def do_match_schedule(mat):
         db.session.commit()
     
     db.session.commit()
+
+    return NEXT_FIGHT_AT
 
 
 def make_config(max_concurrent_groups, max_concurrent_participants):

--- a/webapp/models/matches.py
+++ b/webapp/models/matches.py
@@ -61,6 +61,18 @@ class Match(db.Model):
     def has_result(self):
         return self.results.count() == 1
     
+    def remaining_break_time(self):
+        now = dt.now()
+        break_time = self.group.event_class.between_fights_time
+
+        remaining_time = max(
+            0,
+            int(break_time - (now - self.white.last_fight_at).total_seconds()) if self.white.last_fight_at is not None else 0,
+            int(break_time - (now - self.blue.last_fight_at).total_seconds()) if self.blue.last_fight_at is not None else 0,
+        )
+
+        return remaining_time
+    
     def schedulable(self, consider_preptime = False):
         now = dt.now()
         break_time = self.group.event_class.between_fights_time

--- a/webapp/static/application/match_schedule_view.js
+++ b/webapp/static/application/match_schedule_view.js
@@ -130,6 +130,7 @@ const managedTick = () => {
 }
 
 window.addEventListener("load", () => {
+    sbState.disable_timer = true
     setInterval(managedTick, 50)
 })
 
@@ -282,6 +283,7 @@ document.querySelectorAll("[data-tatami-enter-results]").forEach((btn) => {
                 callup_again.classList.remove('btn-danger-subtle')
 
                 enter_results.classList.add('disabled')
+                sbState.disable_timer = true
             }
         } else {
             document.getElementById('offline-error-message').innerText = response.status + " " + response.statusText
@@ -315,6 +317,8 @@ let do_callup = () => {
     callup_again.innerText = 'Erneut aufrufen'
     callup_again.classList.remove('btn-secondary')
     callup_again.classList.add('btn-danger-subtle')
+
+    sbState.disable_timer = false
 
     enter_results.classList.remove('disabled');
     console.log(enter_results)

--- a/webapp/static/application/scoreboard/controller_action.js
+++ b/webapp/static/application/scoreboard/controller_action.js
@@ -173,6 +173,7 @@ for (const side of sides) {
                 "[data-control='" + side + ".reduce'][data-score='" + score_name + "']")
 
             up_elem.addEventListener('click', () => {
+                up_elem.blur()
                 if (sbState[side].scores[score_name].pending)
                     sbState[side].scores[score_name].pending = false
                 else
@@ -183,6 +184,7 @@ for (const side of sides) {
             });
 
             down_elem.addEventListener('click', () => {
+                down_elem.blur()
                 sbState[side].scores[score_name].pending = false
 
                 if (sbState[side].scores[score_name].value == 0)

--- a/webapp/static/application/scoreboard/controller_state.js
+++ b/webapp/static/application/scoreboard/controller_state.js
@@ -32,7 +32,8 @@ const makeState = (config) => {
                 scores_given: []
             },
             scores: {}
-        }
+        },
+        disable_timer: false
     }
 
     for (const score_name in SBRULES.scores) {

--- a/webapp/static/application/scoreboard/controller_view.js
+++ b/webapp/static/application/scoreboard/controller_view.js
@@ -26,8 +26,13 @@ const renderControls = () => {
         global_time.classList.add('running')
     } else {
         disable_btn(stop_time)
-        enable_btn(start_time)
         global_time.classList.remove('running')
+
+        if (sbState.disable_timer)
+            disable_btn(start_time)
+        else
+            enable_btn(start_time)
+
     }
 
     if (sbState.time.goldenScore) {

--- a/webapp/static/application/scoreboard/scoreboard.css
+++ b/webapp/static/application/scoreboard/scoreboard.css
@@ -91,14 +91,14 @@ body {
     height: 100%;
     width: 100%;
     display: grid;
-    grid-template-columns: 35rem 1fr;
-    grid-template-rows: 100px 1fr 1fr 100px;
+    grid-template-columns: 30vw 1fr;
+    grid-template-rows: 10vh 1fr 1fr 10vh;
 }
 .view-main .main-grid .main-row-name {
     grid-column-start: 2;
     grid-column-end: 3;
-    font-size: 50px;
-    padding: 0.5rem 3rem;
+    font-size: 7vh;
+    padding: 1vh 1vw;
     font-weight: bold;
     display: flex;
     align-items: center;
@@ -154,7 +154,7 @@ body {
 }
 
 .view-main .main-grid .main-row-score .score-grid .score-full_text {
-    font-size: 16rem;
+    font-size: 30vh;
     font-weight: bold;
     text-align: center;
     flex-grow: 1;
@@ -164,7 +164,7 @@ body {
     line-height: 1.0;
     background-color: white;
     z-index: 2;
-    text-shadow: .125rem .125rem 1rem #0006;
+    text-shadow: 0.5vmin .5vmin 1vmin #0006;
 }
 .view-main .main-grid .main-row-score .score-grid .score-full_text:not(.show) {
     display: none;
@@ -175,16 +175,18 @@ body {
 
 .view-main .main-grid .main-row-score .score-grid .score-counter {
     flex-grow: 0;
-    font-size: 200px;
+    font-size: 30vh;
     font-weight: bold;
-    width: 9rem;
+    min-width: 25vh;
     text-align: center;
     line-height: 1.0;
-    border-radius: 1rem;
-    margin: 0 0.125em;
+    border-radius: 2vmin;
+    border-width: 0.35vmin;
+    margin: 0 0.5vw;
     margin-right: 0;
-    padding: 10px 0;
-    text-shadow: .125rem .125rem 1rem #0006;
+    padding: 1vh 0;
+    text-shadow: 0.5vmin .5vmin 1vmin #0006;
+    text-align: center;
 }
 .view-main .main-grid .main-row-score .score-grid .score-counter:empty {
     background-color: transparent;
@@ -200,44 +202,44 @@ body {
 }
 
 .view-main .main-grid .main-row-score .score-grid .score-counter.score-size-md {
-    width: 8rem;
-    font-size: 140px;
-    margin-top: 30px;
+    min-width: 20vh;
+    font-size: 25vh;
+    margin-top: 5vh;
 }
 
 .view-main .main-grid .main-row-score .score-grid .score-counter.score-size-sm {
-    width: 6rem;
-    font-size: 120px;
-    margin-top: 40px;
+    min-width: 15vh;
+    font-size: 20vh;
+    margin-top: 7.5vh;
 }
 
 .view-main .main-grid .main-row-score .score-grid .score-osaekomi {
-    width: 10rem;
+    width: 20vh;
     flex-grow: 0;
-    padding: 0 1rem;
-    margin-left: 2rem;
-    margin-right: 2rem;
+    padding: 0;
+    margin-left: 2vw;
+    margin-right: 1vw;
 }
 
 
 
 .time-osaekomi {
     border: .125em double;
-    height: 7.5rem;
-    width: 7.5rem;
+    height: 20vh;
+    width: 20vh;
     line-height: 1;
-    padding: 1.5rem 0;
-    letter-spacing: -0.25rem;
-    padding-right: 0.25rem;
+    padding: 2.5vh 0;
+    letter-spacing: -0.25vh;
+    padding-right: 0.25vh;
     text-align: center;
     border-radius: 50%;
     margin: 0;
-    margin-top: 0px;
+    margin-top: 0;
     line-height: 0;
-    box-shadow: .25rem .25rem 1rem #0006;
+    box-shadow: 1vmin 1vmin 2vmin #0006;
 
     text-align: center;
-    font-size: 3.75rem;
+    font-size: 12.5vh;
     font-family: 'Reddit Mono', monospace;
     font-weight: 500;
     line-height: 1;
@@ -258,22 +260,22 @@ body {
     display: flex;
     justify-content: flex-end;
     align-items: center;
-    width: 15rem;
-    margin-right: 2rem;
+    width: 30vh;
+    margin-right: 2vw;
 }
 .view-main .main-grid .main-row-score .score-grid .score-shido .card-shido,
 .view-main .main-grid .main-row-score .score-grid .score-shido .card-hansokumake {
-    height: 14rem;
-    width: 4.5rem;
+    height: 30vh;
+    width: 9vh;
     display: block;
-    border-radius: .5rem;
+    border-radius: 2vmin;
     color: #600;
     font-weight: bold;
     line-height: 1;
     text-align: center;
-    margin-left: .5rem;
+    margin-left: 1vw;
     transition: opacity .5s ease-in-out;
-    box-shadow: .25rem .25rem 1rem #0003;
+    box-shadow: .5vmin .5vmin 2vmin #0006;
 }
 
 .view-main .main-grid .main-row-score .score-grid .score-shido .card-shido.hidden,
@@ -288,9 +290,9 @@ body {
     text-transform: uppercase;
 }
 .view-main .main-grid .main-row-score .score-grid .score-shido .card-shido.hidden + .card-shido.hidden + .card-hansokumake {
-    width: 14.5rem;
-    font-size: 12rem;
-    padding-top: 1rem;
+    width: 29vh;
+    font-size: 20vh;
+    padding-top: 5vh;
 }
 
 
@@ -312,10 +314,9 @@ body {
     justify-content: space-between;
 }
 .time-grid .time-header {
-    font-size: 60px;
-    padding-top: 3rem;
-    height: 120px;
-    margin-bottom: 9.875rem;
+    font-size: 10vh;
+    padding-top: 4.5vh;
+    height: 12vh;
     position: absolute;
     top: 0;
     left: 0; right: 0;
@@ -326,7 +327,7 @@ body {
     flex-direction: column;
     justify-content: center;
     background-color: #111;
-    padding: 0.5rem;
+    padding: 1vmin;
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
@@ -334,15 +335,15 @@ body {
 }
 .time-grid .time-main.lit {
     background-color: #fa2;
-    transform: translateY(calc(22px - 50%));
+    transform: translateY(calc(3vh - 50%));
 }
 .time-grid .time-main .time-main-box {
-    padding: 1rem 0;
-    width: 525px;
+    padding: 1vmin 0;
+    width: 28vw;
     text-align: center;
     background-color: #dd6;
     color: black;
-    font-size: 200px;
+    font-size: 20vh;
     font-weight: 900;
     font-family: 'Reddit Mono', monospace;
 }
@@ -350,35 +351,36 @@ body {
     background-color: #6d6;
 }
 .time-grid .time-main .time-main-label {
-    padding: 0.5rem;
+    padding: 1vh;
     padding-bottom: 0;
-    width: 525px;
+    width: 28vw;
     text-align: center;
     color: black;
-    font-size: 30px;
+    font-size: 4vh;
     font-weight: bold;
+    line-height: 1.0;
 }
 .time-grid .time-main .time-main-label:empty {
     display: none;
 }
 .time-grid .time-lower {
     position: absolute;
-    bottom: 1rem;
+    bottom: 1vh;
     display: flex;
     flex-direction: column;
     align-items: center;
 }
 .time-grid .time-class {
-    font-size: 35px;
+    font-size: 5vh;
     padding-bottom: 0;
-    height: 40px;
-    margin-top: 9.875rem;
+    height: 6vh;
+    margin-top: 1vh;
 }
 .time-grid .time-footer {
-    font-size: 30px;
-    padding-bottom: 3rem;
-    height: 40px;
-    margin-top: 1rem;
+    font-size: 4vh;
+    padding-bottom: 6vh;
+    height: 5vh;
+    margin-top: 1vh;
 }
 
 .view-main .main-grid .main-row-time.flashing-medical {
@@ -405,13 +407,13 @@ body {
     width: 100%;
     display: grid;
     grid-template-columns: 100%;
-    grid-template-rows: 100px 1fr 1fr 1fr;
+    grid-template-rows: 10vh 1fr 1fr 1fr;
 }
 
 .view-callup .callup-grid .callup-row-meta {
     background-color: #222;
     color: white;
-    padding: 0 2rem;
+    padding: 1vh 2vw;
 
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;
@@ -421,26 +423,26 @@ body {
 .view-callup .callup-grid .callup-row-meta .meta-matnr {
     grid-row: 1;
     grid-column: 1;
-    font-size: 40px;
+    font-size: 5vh;
     font-weight: bold;
 }
 .view-callup .callup-grid .callup-row-meta .meta-class {
     grid-row: 1;
     grid-column: 3;
-    font-size: 40px;
+    font-size: 5vh;
     font-weight: bold;
     text-align: right;
 }
 .view-callup .callup-grid .callup-row-meta .meta-round {
     grid-row: 1;
     grid-column: 2;
-    font-size: 40px;
+    font-size: 5vh;
     font-weight: bold;
     text-align: center;
 }
 
 .view-callup .callup-grid .callup-row-fighter {
-    padding: 1rem 2rem;
+    padding: 1vh 2vw;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -458,21 +460,21 @@ body {
     color: white;
 }
 .view-callup .callup-grid .callup-row-fighter .fighter-name {
-    font-size: 150px;
+    font-size: 16vh;
     font-weight: bold;
-    margin-bottom: 10px;
-    max-height: 2.35em;
+    margin-bottom: 1vh;
+    max-height: 1.35em;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
 }
 .view-callup .callup-grid .callup-row-fighter .fighter-club {
-    font-size: 50px;
+    font-size: 6vh;
     font-weight: bold;
 }
 
 .view-callup .callup-grid .callup-row-prepare {
-    padding: 1rem 2rem;
+    padding: 1vh 2vw;
     display: flex;
     justify-content: space-around;
     flex-direction: column;
@@ -483,16 +485,16 @@ body {
     display: flex;
 }
 .view-callup .callup-grid .callup-row-prepare .prepare-group .prepare-cta {
-    font-size: 40px;
-    margin-right: 2rem;
+    font-size: 5vh;
+    margin-right: 1vw;
 }
 .view-callup .callup-grid .callup-row-prepare .prepare-group .prepare-group {
-    font-size: 40px;
+    font-size: 5vh;
 }
 .view-callup .callup-grid .callup-row-prepare .prepare-fighter {
     display: flex;
     align-items: center;
-    font-size: 65px;
+    font-size: 8vh;
     font-weight: bold;
 }
 .view-callup .callup-grid .callup-row-prepare .prepare-fighter .fighter-call {
@@ -506,7 +508,7 @@ body {
     min-height: 1em;
     min-width: 0.75em;
     border-radius: 0.25em;
-    margin-right: 1rem;
+    margin-right: 1vw;
     flex-grow: 0;
     flex-shrink: 0;
 }
@@ -537,13 +539,13 @@ body {
     top: 0;
     left: 0;
     right: 0;
-    padding: 5rem 2rem;
-    font-size: 100px;
+    padding: 8vh 3vw;
+    font-size: 12.5vh;
     font-weight: bold;
     text-align: center;
 }
 .view-break .break-matnr {
-    font-size: 250px;
+    font-size: 30vh;
     font-weight: bold;
     text-align: center;
 }
@@ -578,21 +580,21 @@ body {
     top: 0;
     left: 0;
     right: 0;
-    padding: 2rem 2rem;
-    font-size: 50px;
+    padding: 3vh 2vw;
+    font-size: 8vh;
     font-weight: bold;
     text-align: center;
 }
 .view-winner .winner-name {
-    padding: 0 2rem;
-    font-size: 180px;
+    padding: 0 2vw;
+    font-size: 25vh;
     font-weight: bold;
     text-align: center;
-    margin-bottom: 2rem;
-    text-shadow: 0.25rem 0.25rem 0.125rem rgba(0, 0, 0, 0.1);
+    margin-bottom: 1vh;
+    text-shadow: 1vh 1vh 0.5vh rgba(0, 0, 0, 0.1);
     hyphens: auto;
 }
 .view-winner .winner-club {
-    font-size: 100px;
+    font-size: 12.5vh;
     text-align: center;
 }

--- a/webapp/static/application/scoreboard/scoreboard.css
+++ b/webapp/static/application/scoreboard/scoreboard.css
@@ -154,7 +154,7 @@ body {
 }
 
 .view-main .main-grid .main-row-score .score-grid .score-full_text {
-    font-size: 30vh;
+    font-size: 35vh;
     font-weight: bold;
     text-align: center;
     flex-grow: 1;
@@ -266,7 +266,7 @@ body {
 .view-main .main-grid .main-row-score .score-grid .score-shido .card-shido,
 .view-main .main-grid .main-row-score .score-grid .score-shido .card-hansokumake {
     height: 30vh;
-    width: 9vh;
+    width: 5vw;
     display: block;
     border-radius: 2vmin;
     color: #600;
@@ -290,7 +290,7 @@ body {
     text-transform: uppercase;
 }
 .view-main .main-grid .main-row-score .score-grid .score-shido .card-shido.hidden + .card-shido.hidden + .card-hansokumake {
-    width: 29vh;
+    width: 17vw;
     font-size: 20vh;
     padding-top: 5vh;
 }
@@ -581,13 +581,13 @@ body {
     left: 0;
     right: 0;
     padding: 3vh 2vw;
-    font-size: 8vh;
+    font-size: 7vh;
     font-weight: bold;
     text-align: center;
 }
 .view-winner .winner-name {
     padding: 0 2vw;
-    font-size: 25vh;
+    font-size: 20vh;
     font-weight: bold;
     text-align: center;
     margin-bottom: 1vh;
@@ -595,6 +595,6 @@ body {
     hyphens: auto;
 }
 .view-winner .winner-club {
-    font-size: 12.5vh;
+    font-size: 10vh;
     text-align: center;
 }

--- a/webapp/static/application/scoreboard/scoreboard.css
+++ b/webapp/static/application/scoreboard/scoreboard.css
@@ -210,7 +210,7 @@ body {
 .view-main .main-grid .main-row-score .score-grid .score-counter.score-size-sm {
     min-width: 15vh;
     font-size: 20vh;
-    margin-top: 7.5vh;
+    margin-top: 10vh;
 }
 
 .view-main .main-grid .main-row-score .score-grid .score-osaekomi {

--- a/webapp/templates/mod_list/_results.html
+++ b/webapp/templates/mod_list/_results.html
@@ -92,6 +92,10 @@
 {% if g.event.setting('scheduling.use', True) %}
 <p>Die Listen werden auf dieser Matte automatisch geführt. Folglich sind entweder noch keine Listen freigegeben, alle Kämpf erledigt oder es muss zurzeit eine Pause stattfinden.</p>
 
+{% if break_time %}
+    <p class="fw-bold">Geschätzte Pausenzeit: {{ break_time }}</p>
+{% endif %}
+
 {{ buttons.SecondaryButton(text="Seite aktualisieren", href="?") }}
 
 {% else %}

--- a/webapp/templates/mod_list/_schedule.html
+++ b/webapp/templates/mod_list/_schedule.html
@@ -33,7 +33,7 @@
 
 {% if assigned_lists|length %}
     {% call cards.Card() %}
-        {% for list in assigned_lists %}
+        {% for list in assigned_lists if not list.completed %}
             {{ cards.CardHeader(text=list.title, class="tj-schedgrp-btn", actionable=True, attr='data-tj-oneof=\'{"common": ".tj-schedgrp-element", "unique": "#group-' ~ list.id ~ '", "class": "hidden", "classWhen": "off", "ownClass": "active", "ownCommon": ".tj-schedgrp-btn"}\'') }}
             {% call cards.CardBody(class="tj-schedgrp-element hidden", id="group-" ~ list.id) %}
                 {% for match in list.matches.filter_by(scheduled=False, completed=False) if not match.obsolete %}

--- a/webapp/templates/mod_placement/refresh_for_class.html
+++ b/webapp/templates/mod_placement/refresh_for_class.html
@@ -17,7 +17,7 @@
         {% call cards.Card() %}
             {% call cards.CardBody() %}
                 <p>TATAMI wird versuchen, die TN-Daten aus den Anmeldungen aktualisieren.</p>
-                <p>Manuell einer Gruppe hinzugefügte TN werden nicht verändert. Zum Kämpfen freigegebene Gruppen werden ebenfalls nicht verändert.</p>
+                <p>Manuell einer Gruppe hinzugefügte TN werden nicht verändert. Zum Kämpfen freigegebene Gruppen werden (außer bzgl. Name/Verein) ebenfalls nicht verändert.</p>
                 <p>Bitte wählen Sie aus, welche Aktualisierungsverfahren Sie anwenden wollen:</p>
             {% endcall %}
             {% call cards.CardBody() %}

--- a/webapp/templates/mod_scoreboard/_schedule.html
+++ b/webapp/templates/mod_scoreboard/_schedule.html
@@ -38,6 +38,10 @@
     {% if g.event.setting('scheduling.use', True) %}
         <p>Die Listen werden auf dieser Matte automatisch geführt. Folglich sind entweder noch keine Listen freigegeben, alle Kämpf erledigt oder es muss zurzeit eine Pause stattfinden.</p>
 
+        {% if break_time %}
+            <p class="fw-bold">Geschätzte Pausenzeit: {{ break_time }}</p>
+        {% endif %}
+
         {{ buttons.SecondaryButton(href='?', text='Seite aktualisieren') }}
     {% else %}
         <p>Unten können ggf. Kämpfe ausgewählt werden, die jetzt stattfinden können.</p>

--- a/webapp/templates/mod_scoreboard/_schedule.html
+++ b/webapp/templates/mod_scoreboard/_schedule.html
@@ -87,7 +87,7 @@
 <h3>Weitere Kämpfe</h3>
 
 {% call cards.Card() %}
-    {% for list in assigned_lists %}
+    {% for list in assigned_lists if not list.completed %}
         {{ cards.CardHeader(text=list.title, class="tj-schedgrp-btn", actionable=True, attr='data-tj-oneof=\'{"common": ".tj-schedgrp-element", "unique": "#group-' ~ list.id ~ '", "class": "hidden", "classWhen": "off", "ownClass": "active", "ownCommon": ".tj-schedgrp-btn"}\'') }}
         {% call cards.CardBody(class="tj-schedgrp-element hidden", id="group-" ~ list.id) %}
             {% for match in list.matches.filter_by(scheduled=False, completed=False) if not match.obsolete %}

--- a/webapp/views/mod_list.py
+++ b/webapp/views/mod_list.py
@@ -33,8 +33,12 @@ def index():
     for assigned_list in assigned_lists:
         helpers.force_create_list(assigned_list)
 
+    break_time = None
     if g.event.setting('scheduling.use', True):
-        helpers.do_match_schedule(g.mat)
+        break_time = helpers.do_match_schedule(g.mat) or None
+
+    if break_time is not None:
+        break_time = f"{break_time//60}min {break_time%60}s"
 
     helpers.do_promote_scheduled_fights(g.mat)
 
@@ -49,7 +53,7 @@ def index():
         else:
             shown_list = None
 
-    return render_template("mod_list/index.html", assigned_lists=assigned_lists, shown_list=shown_list)
+    return render_template("mod_list/index.html", assigned_lists=assigned_lists, shown_list=shown_list, break_time=break_time)
 
 
 @mod_list_view.route('/display')

--- a/webapp/views/mod_scoreboard.py
+++ b/webapp/views/mod_scoreboard.py
@@ -34,12 +34,16 @@ def managed():
     for assigned_list in assigned_lists:
         helpers.force_create_list(assigned_list)
 
+    break_time = None
     if g.event.setting('scheduling.use', True):
-        helpers.do_match_schedule(g.mat)
+        break_time = helpers.do_match_schedule(g.mat) or None
+
+    if break_time is not None:
+        break_time = f"{break_time//60}min {break_time%60}s"
 
     helpers.do_promote_scheduled_fights(g.mat)
 
-    return render_template("mod_scoreboard/managed.html", assigned_lists=assigned_lists)
+    return render_template("mod_scoreboard/managed.html", assigned_lists=assigned_lists, break_time=break_time)
 
 
 @mod_scoreboard_view.route('/managed/api/reload')
@@ -59,9 +63,13 @@ def api_reload():
     for assigned_list in assigned_lists:
         helpers.force_create_list(assigned_list)
 
+    break_time = None
     if g.event.setting('scheduling.use', True):
-        helpers.do_match_schedule(g.mat)
+        break_time = helpers.do_match_schedule(g.mat) or None
+
+    if break_time is not None:
+        break_time = f"{break_time//60}min {break_time%60}s"
 
     helpers.do_promote_scheduled_fights(g.mat)
 
-    return render_template("mod_scoreboard/_schedule.html", assigned_lists=assigned_lists)
+    return render_template("mod_scoreboard/_schedule.html", assigned_lists=assigned_lists, break_time=break_time)


### PR DESCRIPTION
## Inhalt

Diese PR enthält verschiedene Verbesserungen im Scoreboard und im Scoreboard-Controller, nämlich:

- Beendete Listen werden im Listenführungs/managed Scoreboard-Modul nicht mehr in der linken Spalte angezeigt
- Der Timer-Start-Knopf ist deaktiviert, solange der Kampf nicht aufgerufen worden ist
- Fokus-Blur funktioniert jetzt wieder für die Up/Down-Elemente im Scoreboard-Controller
- Das Scoreboard wurde leicht angepasst und nutzt jetzt viewport-spezifische Einheiten, sodass es nicht mehr erforderlich ist, die Zoom-Funktion zu nutzen
- Im Refresh-Tool (Hauptliste) wird klargestellt, dass Name und Verband auch in eröffneten Listen aktualisiert werden
- Eine Schätzung für die vsstl. Wartezeit wurde hinzugefügt

## Relevante Issues

- closes #51
- closes #52
- resolves partially #53

## Release Notes

```
- Listenführung/Scoreboard zeigt erledigte Listen nicht mehr in linker Spalte an (#52 -> #58)
- Im Managed Scoreboard kann die Zeit nicht mehr gestartet werden, wenn kein Aufruf erfolgt ist (#52 -> #58)
- Fokus Blur funktioniert jetzt wieder im Scoreboard (#52 -> #58)
- Das Scoreboard wurde leicht angepasst und ist jetzt viewport-relative (#51 -> #58)
    - Damit sollte es nicht mehr notwendig sein, einen tabspezifischen Zoom zu setzen.
- Eine Schätzung für die vsstl. Wartezeit wurde im Managed Scoreboard/Listenführungsmodul hinzugefügt (#52 -> #58)
```

## Anmerkungen und Implementierungsdetails

n. n.