### PR TITLE
Fehlerbehebung in der Listenverwaltung

### DIFF
--- a/webapp/helpers/list_helper.py
+++ b/webapp/helpers/list_helper.py
@@ -105,6 +105,12 @@ def dump_list(list, group):
             if existing_match is not None:
                 existing_match = _check_if_match_is_obsolete(existing_match, item['match'])
 
+                # Update some mostly informational properties just in case
+                existing_match.is_playoff = list.is_playoff(match_id)
+                existing_match.list_tags = ",".join(match_tags)
+                existing_match.match_list_no = match_no
+
+
             if existing_match is None:
                 match = Match(event=group.event, event_class=group.event_class, group=group)
                 db.session.add(match)

--- a/webapp/helpers/list_helper.py
+++ b/webapp/helpers/list_helper.py
@@ -160,6 +160,7 @@ def reset_list(group):
 
 
 def _check_if_match_is_obsolete(dbmatch, listmatch):
+    listmatch_result = listmatch.get_result()
     if (dbmatch.white.id != listmatch.get_white().get_id() or
         dbmatch.blue.id != listmatch.get_blue().get_id()):
         
@@ -178,6 +179,13 @@ def _check_if_match_is_obsolete(dbmatch, listmatch):
         else:
             dbmatch.white = Participant.query.filter_by(id=listmatch.get_white().get_id()).one()
             dbmatch.blue = Participant.query.filter_by(id=listmatch.get_blue().get_id()).one()
+
+    elif (listmatch_result and listmatch_result.get_absolute_winner()):
+        dbmatch.obsolete = True
+        dbmatch.scheduled = False
+        dbmatch.called_up = False
+        dbmatch.running = False
+        dbmatch = None
 
     elif dbmatch.obsolete is None:
         dbmatch.obsolete = False

--- a/webapp/listslib/metalist.py
+++ b/webapp/listslib/metalist.py
@@ -162,6 +162,12 @@ class MetaList:
 
                 self._matches[match_id] = match_data
 
+        # add resolv-matches to playoffs
+
+        for rm in self._com.findall("rules/score/resolve-match"):
+            match_id = rm.attrib['id']
+            self._playoff_match_ids.append(match_id)
+
     """
         __load_single_match()
 

--- a/webapp/listslib/metalist.py
+++ b/webapp/listslib/metalist.py
@@ -693,6 +693,14 @@ class MetaList:
             elif blue_disqualified:
                 mr = match.mk_result()
                 mr.set_absolute_winner('white')
+
+                # Set scores in accordance with Art. 8.2.2 of the SOR-Refereeing Rules
+
+                mr.set_points_white(1)
+                mr.set_score_white(10)
+                mr.set_points_blue(0)
+                mr.set_score_blue(0)
+
                 mr.set_data_white((), (), False)
                 mr.set_data_blue((), (), True)
                 self.enter_results(obj, mr)
@@ -700,6 +708,14 @@ class MetaList:
             elif white_disqualified:
                 mr = match.mk_result()
                 mr.set_absolute_winner('blue')
+
+                # Set scores in accordance with Art. 8.2.2 of the SOR-Refereeing Rules
+
+                mr.set_points_white(0)
+                mr.set_score_white(0)
+                mr.set_points_blue(1)
+                mr.set_score_blue(10)
+
                 mr.set_data_white((), (), True)
                 mr.set_data_blue((), (), False)
                 self.enter_results(obj, mr)
@@ -835,10 +851,6 @@ class MetaList:
             match_id = m['match']
             mr = obj._match_results[match_id]
             mobj = mr.get_match()
-
-            # absolute winners do not earn any points
-            if mr.get_absolute_winner() in ['white', 'blue']:
-                continue
 
             white_key = mobj.get_white()
             if white_key in base_data:  # may be false due to scopes

--- a/webapp/models/matches.py
+++ b/webapp/models/matches.py
@@ -52,9 +52,9 @@ class Match(db.Model):
     obsolete = db.Column(db.Boolean)
 
     def printable(self):
-        return f"Match<{self.listslib_match_id}>('{self.white.full_name}', '{self.blue.full_name}'" + \
+        return f"{self.id}. Match<{self.listslib_match_id}>\n  ('{self.white.full_name}', '{self.blue.full_name}'" + \
             (', obsolete=True' if self.obsolete else '') + \
-                (f", result={self.get_result()[1].printable()}" if self.has_result() else '') + \
+                (f", result=\n    {self.get_result()[1].printable()}" if self.has_result() else '') + \
                     ")"
 
     def get_result(self):
@@ -142,7 +142,7 @@ class MatchResult(db.Model):
     full_time = db.Column(db.Integer())
 
     def printable(self):
-        return f"MatchResult(winner={self.winner()}, score={self.score()}, loser_dq={self.loser_disqualified()}, loser_rm={self.loser_removed()})"
+        return f"{self.id}. MatchResult(winner='{self.winner()}', score={self.score()}, loser_dq={self.loser_disqualified()}, loser_rm={self.loser_removed()})"
 
     def winner(self):
         if self.is_white_winner:

--- a/webapp/models/matches.py
+++ b/webapp/models/matches.py
@@ -51,6 +51,12 @@ class Match(db.Model):
     # This flag will be set, when this match is obsolete because of a change in the lists
     obsolete = db.Column(db.Boolean)
 
+    def printable(self):
+        return f"Match<{self.listslib_match_id}>('{self.white.full_name}', '{self.blue.full_name}'" + \
+            (', obsolete=True' if self.obsolete else '') + \
+                (f", result={self.get_result()[1].printable()}" if self.has_result() else '') + \
+                    ")"
+
     def get_result(self):
         if self.results.count() != 1:
             return True, MatchResult(match=self)
@@ -133,7 +139,10 @@ class MatchResult(db.Model):
     is_blue_removed = db.Column(db.Boolean()) # e. g. injury
 
     scoreboard_data = db.Column(db.Text())
-    full_time = db.Column(db.Integer())    
+    full_time = db.Column(db.Integer())
+
+    def printable(self):
+        return f"MatchResult(winner={self.winner()}, score={self.score()}, loser_dq={self.loser_disqualified()}, loser_rm={self.loser_removed()})"
 
     def winner(self):
         if self.is_white_winner:

--- a/webapp/templates/mod_global_list/debug.html
+++ b/webapp/templates/mod_global_list/debug.html
@@ -1,0 +1,25 @@
+{%- import "components/layout.html" as layout -%}
+{%- import "components/datasets.html" as datasets -%}
+{%- import "components/buttons.html" as buttons -%}
+{%- import "components/form.html" as form -%}
+
+
+{% extends "layouts/application.html" %}
+{% block title %}Hauptliste{% endblock %}
+{% block body %}
+{% call layout.Container() %}
+
+    <h1>Debugging-Ausgabe für {{ group.title }}</h1>
+
+    <h2>Anstehende Kämpfe</h2>
+
+    <pre><code>{{ match_schedule }}</code></pre>
+
+    <h2>Datenbank-Matches</h2>
+
+    <pre><code>{{ dbmatches }}</code></pre>
+
+    {{ buttons.PrimaryButton(href=url_for('mod_global_list.index', event=g.event.slug, group=group.id), text="Zurück zur Hauptliste") }}
+
+{% endcall %}
+{% endblock body %}

--- a/webapp/templates/mod_global_list/index.html
+++ b/webapp/templates/mod_global_list/index.html
@@ -80,6 +80,9 @@
     {% if current_group %}
         {%- call colboard.ColboardColumn(span=3) -%}
             {% call colboard.ColboardColumnHeader(title=current_group.title) %}
+                {%- call buttons.SubtleButton(href=url_for('mod_global_list.debug', event=g.event.slug, id=current_group.id), disabled=not current_group.marked_ready) -%}
+                    {{ buttons.ButtonIcon(icon="bug", label="Debug") }}
+                {%- endcall -%}
                 {%- call buttons.SubtleButton(href=url_for('mod_global_list.parameters', event=g.event.slug, id=current_group.id), disabled=not current_group.marked_ready) -%}
                     {{ buttons.ButtonIcon(icon="database-settings", label="Parameter") }}
                 {%- endcall -%}

--- a/webapp/templates/mod_global_list/parameters.html
+++ b/webapp/templates/mod_global_list/parameters.html
@@ -57,8 +57,6 @@
     <p class="fs-sm text-secondary-dark text-right">DQ = Disqualifikation, Aus = Ausgeschieden</p>
 
     {{ buttons.PrimaryButton(href=url_for('mod_global_list.index', event=g.event.slug, group=group.id), text="Zurück zur Hauptliste") }}
-    </div>
-</div>
 
 {% endcall %}
 {% endblock body %}

--- a/webapp/views/mod_placement.py
+++ b/webapp/views/mod_placement.py
@@ -76,8 +76,9 @@ def add_group(id):
         group.max_weight = int(float(request.form['max_weight']) * 1000) if request.form['max_weight'] else None
 
         if request.form['system']:
-            group.system_id = int(request.form['system'])
-            group.list_break_count = group.list_system().break_count
+            system = ListSystem.all_enabled().filter_by(id=request.form['system']).one_or_none()
+            group.system_id = system.id
+            group.list_break_count = system.break_count
         else:
             group.system_id = None
 


### PR DESCRIPTION
## Inhalt

Diese PR enthält Verbesserungen in der Listenverwaltung:

- Ein Fehler wurde behoben, der das Erstellen von Listen mit ausgewählten Listensystem verhindert hatte.
- "Absolute Winners" (d. h. Gegner/innen disqualifizierter bzw. ausgeschiedener Kämpfer/innen) erhalten nun 1/10 Punkte für den Kampf
- Angesetzte Matches, für die ein "Absolute Winner" gesetzt ist, werden jetzt als obsolet markiert
- Eine Debug-Ausgabe wurde in der Hauptliste hinzugefügt
- Resolve-Matches (Doppelpool-Finale) gelten jetzt als Playoff-Matches und werden entsprechend richtig eingegeben

## Relevante Issues

- closes #54

## Release Notes

```
- Doppelpool-Finals werden jetzt richtig geladen (#54 -> #59)
- Eine Debug-Ausgabe für das Scheduling einer Gruppe wurde in der Hauptliste hinzugefügt (-> #59)
- Verbesserung des Umgangs mit den Gegner/innen diesqualifizierter bzw. ausgeschiedener Kämpfer/innen (-> #59)
    - Diese erhalten nun im Einklang mit den IJF-Wettkampfregeln 1/10 Punkte anstatt, dass die Kämpfe wie bisher insgesamt nicht gewertet werden.
    - Kämpfe, die durch einen absolute Winner bereits ein Ergebnis haben, werden jetzt als obsolet markiert.
```

## Anmerkungen und Implementierungsdetails

n. n.