### PR TITLE
Gemeinsame Anzeige von Verein und Verband

### DIFF
--- a/event_setting_defaults.txt
+++ b/event_setting_defaults.txt
@@ -4,7 +4,7 @@ scheduling.max_concurrent_participants: 30
 scheduling.plan_ahead: 5
 count_weighin_as_registration: False
 write_activity_log: True
-use_association_instead_of_club: False
+show_for_club: club
 proximity_placement.hide_name: False
 proximity_placement.hide_club: False
 place.differentiate-better.third: False

--- a/webapp/models/participants.py
+++ b/webapp/models/participants.py
@@ -103,6 +103,19 @@ class Registration(db.Model):
         base_hash = base64.b16encode(hashlib.md5(base_hash).digest()).decode()
         return "".join([*map(lambda x: PRONOUNCABLE_HASH[x], base_hash[:4])]).capitalize()
     
+    def for_club(self, option='club'):
+        match option:
+            case 'club':
+                return self.club
+            case 'club+assoc':
+                return self.club + ' (' + self.association.short_name + ')'
+            case 'assoc+club':
+                return self.association.short_name + ' · ' + self.club
+            case 'assoc':
+                return self.association.name
+        
+        return '??'
+
     def matches_status(self, filter):
         # All registrations match no filter
         if filter is None:

--- a/webapp/templates/components/datasets.html
+++ b/webapp/templates/components/datasets.html
@@ -52,8 +52,8 @@
 </tr>
 {%- endmacro -%}
 
-{%- macro TableCheckColumn(name="", id="", type="checkbox") -%}
-<td class="table-check-container"><input type="{{ type }}" name="{{ name }}" id="{{ id }}"></td>
+{%- macro TableCheckColumn(name="", id="", type="checkbox", value="") -%}
+<td class="table-check-container"><input type="{{ type }}" name="{{ name }}" value="{{ value or id }}" id="{{ id }}"></td>
 {%- endmacro -%}
 
 {%- macro TableColumn(text=None, check_id=None) -%}

--- a/webapp/templates/event-manager/config.html
+++ b/webapp/templates/event-manager/config.html
@@ -54,9 +54,6 @@
 
             {{ form.FormCheck(id='write_activity_log', name='write_activity_log', label='Veranstaltungsprotokoll schreiben', checked=g.event.setting('write_activity_log', True)) }}
 
-            {{ form.FormCheck(id='use_association_instead_of_club', name='use_association_instead_of_club', label='Anstelle des Vereins wird für die Listen, das Scoreboard u. a. der Verband verwendet', checked=g.event.setting('use_association_instead_of_club', False)) }}
-            {{ form.FormNotice(text='Dies ist insb. bei Meisterschaften mit Vorqualifikation auszuwählen, bei denen der Verband maßgeblich ist. Eine Änderung dieser Einstellung gilt nur für TN, die danach einer Gruppe zugewiesen werden.') }}
-
             {{ form.FormCheck(id='proxplace_hide_name', name='proxplace_hide_name', label='TN-Name bei Einteilung nach gewichtsnahen Gruppen ausblenden', checked=g.event.setting('proximity_placement.hide_name', False)) }}
 
             {{ form.FormCheck(id='proxplace_hide_club', name='proxplace_hide_club', label='Verein bzw. Verband bei Einteilung nach gewichtsnahen Gruppen ausblenden', checked=g.event.setting('proximity_placement.hide_club', False)) }}
@@ -64,6 +61,17 @@
             {{ form.FormCheck(id='differentiate_better_third_place', name='differentiate_better_third_place', label='Dritten Platz ggf. auskämpfen (3. vs. 4. Platz)', checked=g.event.setting('place.differentiate-better.third', False)) }}
 
             {{ form.FormCheck(id='differentiate_better_fifth_place', name='differentiate_better_fifth_place', label='Fünften Platz ggf. auskämpfen (5. vs. 6. Platz)', checked=g.event.setting('place.differentiate-better.fifth', False)) }}
+        {% endcall %}
+        {% call cards.CardBody() %}
+            {% set show_for_club = g.event.setting('show_for_club', 'club') %}
+            {{ form.Label(for_id='show_for_club', text="Anzeige von Verband/Verein") }}
+            {% call form.Select(id='show_for_club', name='show_for_club') %}
+                {{ form.SelectOption(value='club', selected=(show_for_club == 'club'), text="Nur Verein") }}
+                {{ form.SelectOption(value='club+assoc', selected=(show_for_club == 'club+assoc'), text="Verein und Verband") }}
+                {{ form.SelectOption(value='assoc+club', selected=(show_for_club == 'assoc+club'), text="Verband und Verein") }}
+                {{ form.SelectOption(value='assoc', selected=(show_for_club == 'assoc'), text="Nur Verband") }}
+            {% endcall %}
+            {{ form.FormNotice(text='Dies ist insb. bei Meisterschaften mit Vorqualifikation auszuwählen, bei denen der Verband maßgeblich ist. Eine Änderung dieser Einstellung gilt nur für TN, die danach einer Gruppe zugewiesen werden.') }}
         {% endcall %}
         {% call cards.CardBody() %}
             {{ form.Label(for_id='sbid', text="Scoreboard") }}

--- a/webapp/templates/event-manager/config.html
+++ b/webapp/templates/event-manager/config.html
@@ -66,12 +66,12 @@
             {% set show_for_club = g.event.setting('show_for_club', 'club') %}
             {{ form.Label(for_id='show_for_club', text="Anzeige von Verband/Verein") }}
             {% call form.Select(id='show_for_club', name='show_for_club') %}
-                {{ form.SelectOption(value='club', selected=(show_for_club == 'club'), text="Nur Verein") }}
-                {{ form.SelectOption(value='club+assoc', selected=(show_for_club == 'club+assoc'), text="Verein und Verband") }}
-                {{ form.SelectOption(value='assoc+club', selected=(show_for_club == 'assoc+club'), text="Verband und Verein") }}
-                {{ form.SelectOption(value='assoc', selected=(show_for_club == 'assoc'), text="Nur Verband") }}
+                {{ form.SelectOption(value='club', selected=(show_for_club == 'club'), text="Verein") }}
+                {{ form.SelectOption(value='club+assoc', selected=(show_for_club == 'club+assoc'), text="Verein (Verband)") }}
+                {{ form.SelectOption(value='assoc+club', selected=(show_for_club == 'assoc+club'), text="Verband · Verein") }}
+                {{ form.SelectOption(value='assoc', selected=(show_for_club == 'assoc'), text="Verband") }}
             {% endcall %}
-            {{ form.FormNotice(text='Dies ist insb. bei Meisterschaften mit Vorqualifikation auszuwählen, bei denen der Verband maßgeblich ist. Eine Änderung dieser Einstellung gilt nur für TN, die danach einer Gruppe zugewiesen werden.') }}
+            {{ form.FormNotice(text='Dies ist insb. bei Meisterschaften mit Vorqualifikation anzupassen, bei denen der Verband maßgeblich ist. Eine Änderung dieser Einstellung gilt nur für TN, die danach einer Gruppe zugewiesen werden.') }}
         {% endcall %}
         {% call cards.CardBody() %}
             {{ form.Label(for_id='sbid', text="Scoreboard") }}

--- a/webapp/templates/mod_placement/for_class.html
+++ b/webapp/templates/mod_placement/for_class.html
@@ -31,7 +31,7 @@
                 {%- call list.ListItem() -%}
                     {%- call list.ListItemBody() -%}
                         {{ list.ListItemBodyHeader(reg.first_name + ' ' + reg.last_name) }}
-                        {{ list.ListItemBodyDetail(reg.association.name if g.event.setting('use_association_instead_of_club', False) and reg.association else reg.club) }}
+                        {{ list.ListItemBodyDetail(reg.for_club(g.event.setting('show_for_club', 'club'))) }}
                         {{ list.ListItemBodyDetail(reg.verified_weight / 1000 ~ ' kg') }}
                     {%- endcall -%}
                     {%- call list.ListItemMenu() -%}

--- a/webapp/templates/mod_placement/registration/assign.html
+++ b/webapp/templates/mod_placement/registration/assign.html
@@ -35,7 +35,7 @@
                         {{ form.SelectDefaultOption() }}
                         {% for reg in registrations.all() %}
                             {% call form.SelectOption(value=reg.id, selected=(registration and registration.id == reg.id)) %}
-                                {{ reg.last_name }}, {{ reg.first_name }} &ndash; {{ reg.association.name if g.event.setting('use_association_instead_of_club', False) and reg.association else reg.club }} ({{ reg.verified_weight / 1000 }} kg)
+                                {{ reg.last_name }}, {{ reg.first_name }} &ndash; {{ reg.for_club(g.event.setting('show_for_club', 'club')) }} ({{ reg.verified_weight / 1000 }} kg)
                             {% endcall %}
                         {% endfor %}
                     {% endcall %}

--- a/webapp/templates/mod_placement/registration/assign_all-proximity.html
+++ b/webapp/templates/mod_placement/registration/assign_all-proximity.html
@@ -50,7 +50,8 @@
                             {{ segmentation.SegmentationControl(id='before_'~reg.id, name='before', value=reg.id, checked=default_segmentation[reg.id]) }}
                         {% endif %}
                         {% call segmentation.SegmentationItem(checkbox=True, id="allow_" ~ reg.id, name="allow", value=reg.id, checked=True) %}
-                            <strong>{{ reg.verified_weight / 1000 }} kg</strong> &ndash; {% if g.event.setting('proximity_placement.hide_name', False) %}<span class="font-monospace">{{ reg.anon_name() }}</span>{% else %}{{ reg.first_name }} {{ reg.last_name }}{% endif %} ({% if g.event.setting('proximity_placement.hide_club', False) %}<span class="font-monospace">{{ reg.anon_club() }}</span>{% else %}{{ reg.association.name if g.event.setting('use_association_instead_of_club', False) and reg.association else reg.club }}{% endif %})
+                            <strong>{{ reg.verified_weight / 1000 }} kg</strong> &ndash; {% if g.event.setting('proximity_placement.hide_name', False) %}<span class="font-monospace">{{ reg.anon_name() }}</span>{% else %}{{ reg.first_name }} {{ reg.last_name }}{% endif %}
+                                ({% if g.event.setting('proximity_placement.hide_club', False) %}<span class="font-monospace">{{ reg.anon_club() }}</span>{% else %}{{ reg.for_club(g.event.setting('show_for_club', 'club')) }}{% endif %})
                         {% endcall %}
                     {% endfor %}
                 {% endcall %}

--- a/webapp/views/event_manager.py
+++ b/webapp/views/event_manager.py
@@ -137,7 +137,7 @@ def save_config():
     elif request.form['form'] == 'misc':
         g.event.save_setting('count_weighin_as_registration', 'count_weighin_as_registration' in request.form)
         g.event.save_setting('write_activity_log', 'write_activity_log' in request.form)
-        g.event.save_setting('use_association_instead_of_club', 'use_association_instead_of_club' in request.form)
+        g.event.save_setting('show_for_club', request.form['show_for_club'])
 
         g.event.save_setting('proximity_placement.hide_name', 'proxplace_hide_name' in request.form)
         g.event.save_setting('proximity_placement.hide_club', 'proxplace_hide_club' in request.form)

--- a/webapp/views/mod_placement.py
+++ b/webapp/views/mod_placement.py
@@ -183,10 +183,7 @@ def assign(id):
 
                 participant.registration = registration
 
-                if g.event.setting('use_association_instead_of_club', False) and registration.association:
-                    participant.association_name = registration.association.name
-                else:
-                    participant.association_name = registration.club
+                participant.association_name = registration.for_club(g.event.setting('show_for_club', 'club'))
 
                 registration.placed = True
                 registration.placed_at = registration.placed_at or dt.now()
@@ -327,10 +324,7 @@ def assign_all_predefined(id):
 
                 participant.registration = registration
 
-                if g.event.setting('use_association_instead_of_club', False) and registration.association:
-                    participant.association_name = registration.association.name
-                else:
-                    participant.association_name = registration.club
+                participant.association_name = registration.for_club(g.event.setting('show_for_club', 'club'))
 
                 registration.placed = True
                 registration.placed_at = registration.placed_at or dt.now()
@@ -407,10 +401,7 @@ def assign_all_proximity(id):
 
             participant.registration = registration
 
-            if g.event.setting('use_association_instead_of_club', False) and registration.association:
-                participant.association_name = registration.association.name
-            else:
-                participant.association_name = registration.club
+            participant.association_name = registration.for_club(g.event.setting('show_for_club', 'club'))
 
             registration.placed = True
             registration.placed_at = registration.placed_at or dt.now()
@@ -805,10 +796,7 @@ def _refresh_participant_name(participant, registration):
     if len(participant.full_name) > 21:
          participant.full_name = f"{registration.first_name[0]}. {registration.last_name}"
 
-    if g.event.setting('use_association_instead_of_club', False) and registration.association:
-        participant.association_name = registration.association.name
-    else:
-        participant.association_name = registration.club
+    participant.association_name = registration.for_club(g.event.setting('show_for_club', 'club'))
 
 
 def _refresh_participant_weight(event_class, participant, registration, group):
@@ -862,10 +850,7 @@ def _refresh_participant_weight(event_class, participant, registration, group):
 
         participant.registration = registration
 
-        if g.event.setting('use_association_instead_of_club', False) and registration.association:
-            participant.association_name = registration.association.name
-        else:
-            participant.association_name = registration.club
+        participant.association_name = registration.for_club(g.event.setting('show_for_club', 'club'))
 
         registration.placed = True
         registration.placed_at = registration.placed_at or dt.now()


### PR DESCRIPTION
## Inhalt

Diese PR erweitert die bisherigen Auswahlmöglichkeiten (nur Verein, nur Verband) um die Optionen "Verein (Verband)" und "Verband · Verein" (jeweils beim Verband nur das Kürzel).

Außerdem wird ein Fehler behoben, der durch #60 eingeführt wurde und dafür gesorgt hatte, dass die TN-Liste nicht mehr abrufbar war.

## Relevante Issues

n. n.

## Release Notes

```
- Erweiterte Auswahlmöglichkeiten für Vereins- und Verbandsanzeige (-> #61)
    - Neben (bisher möglichen) Optionen nur Verein und nur Verband gibt es jetzt auch die Optionen "Verein (Verband)" und "Verband · Verein".
    - Bei diesen beiden Optionen wird für den Verband das Verbandskürzel angezeigt.
    - Die Option "Nur Verein" bleibt die Standardeinstellung
```

n. n.

## Anmerkungen und Implementierungsdetails

- Es wurde eine neue Veranstaltungseinstellung `show_for_club` mit dem Standardwert `club` eingefügt.
- Die Veranstaltungseinstellung `use_association_instead_of_club` wird nicht mehr verwendet